### PR TITLE
Interface importing

### DIFF
--- a/src/commands/test/examples/shouldnt_work/test_this_shouldnt_work.cairo
+++ b/src/commands/test/examples/shouldnt_work/test_this_shouldnt_work.cairo
@@ -1,0 +1,11 @@
+%lang starknet
+from basic import BasicContract
+
+@view
+func test_this_shouldnt_work{syscall_ptr : felt*, range_check_ptr}(addr: felt):
+    BasicContract.increase_balance(addr, 3)
+    let (balance) = BasicContract.get_balance(addr)
+    assert balance = 3
+
+    return ()
+end

--- a/src/commands/test/runner_test.py
+++ b/src/commands/test/runner_test.py
@@ -18,7 +18,7 @@ async def test_run_valid_tests():
         ]
     )
     await runner.run_tests_in(
-        test_root_dir, match_pattern=re.compile(r".*(nested|failure|broken).*")
+        test_root_dir, match_pattern=re.compile(r".*(nested|failure|broken|shouldnt).*")
     )
 
 


### PR DESCRIPTION
A simple example - you can run tests by running pytest with:
`--target src/commands/test/runner_test.py::test_run_valid_tests`
Basically what this does is include `examples` path (with basic.cairo) within `cairo_path`, and runs the test function 