### PR TITLE
Use Python 3.8 in the build process

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -13,10 +13,10 @@ jobs:
         os: [ ubuntu-18.04, macOS-10.15 ]  # TODO: Fix windows gmp.h not found issue, and add a windows binary
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7.12
+      - name: Set up Python 3.8.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.12
+          python-version: 3.8.12
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Python 3.7.12 doesn't support ARM architecture, which probably caused the following error:
`zsh: bad CPU type in executable: protostar`