### PR TITLE
Fix installing a package without master branch

### DIFF
--- a/src/commands/install/pull_package_submodules.py
+++ b/src/commands/install/pull_package_submodules.py
@@ -22,4 +22,4 @@ def pull_package_submodules(
             on_submodule_update_start(
                 PackageInfo(name=submodule.name, url=submodule.url)
             )
-            repo.git.execute(["git", "submodule", "update", "--init"])
+            repo.git.execute(["git", "submodule", "update", "--init", submodule.path])

--- a/src/commands/install/pull_package_submodules.py
+++ b/src/commands/install/pull_package_submodules.py
@@ -22,4 +22,4 @@ def pull_package_submodules(
             on_submodule_update_start(
                 PackageInfo(name=submodule.name, url=submodule.url)
             )
-            submodule.update(init=True)
+            repo.git.execute(["git", "submodule", "update", "--init"])

--- a/src/commands/install/pull_package_submodules_test.py
+++ b/src/commands/install/pull_package_submodules_test.py
@@ -50,7 +50,7 @@ def package_repo_dir(tmpdir: str) -> str:
 
 @pytest.fixture
 def package_repo(package_repo_dir: str, the_packages_file_name: str) -> Repo:
-    repo = Repo.init(package_repo_dir)
+    repo = Repo.init(package_repo_dir, initial_branch="main")
 
     the_file_path = path.join(package_repo_dir, the_packages_file_name)
     with open(path.join(the_file_path), "w", encoding="utf-8") as file:


### PR DESCRIPTION
```
19:24:41 [INFO] Installing cairo_integer_types (https://github.com/bellissimogiorno/cairo-integer-types)
19:24:42 [WARNING] Failed to checkout tracking branch refs/heads/master
19:24:42 [INFO] Installing cairo_contracts (https://github.com/OpenZeppelin/cairo-contracts)
19:24:44 [WARNING] Failed to checkout tracking branch refs/heads/master
19:24:44 [INFO] Skipping reset on branch 'HEAD' of submodule repo '<git.repo.base.Repo '/Users/timelock/swm/starkware/access-protocol-starknet/.git/modules/cairo_contracts'>' as it contains un-pushed commits
```

https://github.com/gitpython-developers/GitPython/issues/1058