### PR TITLE
Test runner improved

### DIFF
--- a/protostar.py
+++ b/protostar.py
@@ -113,7 +113,7 @@ cmd_update_parser.add_argument(
 cmd_upgrade_parser = root_subparsers.add_parser("upgrade")
 
 cmd_test_parser = root_subparsers.add_parser("test")
-cmd_test_parser.add_argument("tests-root", type=directory)
+cmd_test_parser.add_argument("target", type=Path)
 cmd_test_parser.add_argument(
     "--omit",
     "-o",

--- a/src/cli.py
+++ b/src/cli.py
@@ -48,7 +48,7 @@ async def cli(args, script_root: Path, protostar_binary_dir: Optional[Path]):
             upgrade()
         elif args.command == "test":
             await run_test_runner(
-                getattr(args, "tests-root"),
+                args.target,
                 project=current_project,
                 omit=args.omit,
                 match=args.match,

--- a/src/commands/test/collector.py
+++ b/src/commands/test/collector.py
@@ -23,10 +23,7 @@ class TestCollector:
     target: Path
     include_paths: Optional[List[str]] = None
     target_function: Optional[str] = None
-    test_filename_re = [
-            re.compile(r'^test_.*\.cairo'),
-            re.compile(r'^.*_test.cairo')
-        ]
+    test_filename_re = [re.compile(r"^test_.*\.cairo"), re.compile(r"^.*_test.cairo")]
 
     def __post_init__(self):
         if re.match(r"^.*\.cairo::.*", self.target.name):
@@ -42,26 +39,30 @@ class TestCollector:
     ) -> List[TestSubject]:
 
         test_files = self.get_test_files()
-        
+
         if match_pattern:
             test_files = filter(lambda file: match_pattern.match(file.name), test_files)
         if omit_pattern:
-            test_files = filter(lambda file: not omit_pattern.match(file.name), test_files) 
-        
+            test_files = filter(
+                lambda file: not omit_pattern.match(file.name), test_files
+            )
+
         test_files = map(self.build_test_subject, test_files)
-        non_empty = filter(lambda file: (file.test_functions) != [], test_files )
+        non_empty = filter(lambda file: (file.test_functions) != [], test_files)
         return list(non_empty)
-    
+
     def build_test_subject(self, file_path: Path):
         test_functions = self._collect_test_functions(file_path)
         if self.target_function:
-            test_functions = [f for f in test_functions if f['name'] == self.target_function]
+            test_functions = [
+                f for f in test_functions if f["name"] == self.target_function
+            ]
         return TestSubject(
-                        test_path=file_path,
-                        test_functions=test_functions,
-                    )
+            test_path=file_path,
+            test_functions=test_functions,
+        )
 
-    def get_test_files(self) -> Generator[Path, None, None]:        
+    def get_test_files(self) -> Generator[Path, None, None]:
         if not self.target.is_dir():
             yield self.target
             return
@@ -74,7 +75,6 @@ class TestCollector:
     @classmethod
     def is_test_file(cls, filename: str) -> bool:
         return any(test_re.match(filename) for test_re in cls.test_filename_re)
-
 
     def _collect_test_functions(self, file_path: Path) -> List[dict]:
         try:

--- a/src/commands/test/collector.py
+++ b/src/commands/test/collector.py
@@ -1,9 +1,8 @@
-from typing import Generator
+from typing import Generator, List, Optional, Pattern
 import os
 from dataclasses import dataclass
 from pathlib import Path
 import re
-from typing import List, Optional, Pattern
 
 from starkware.cairo.lang.compiler.preprocessor.preprocessor_error import (
     PreprocessorError,
@@ -67,7 +66,7 @@ class TestCollector:
             yield self.target
             return
         for root, _, files in os.walk(self.target):
-            test_files = map(lambda file: Path(root, file), files)
+            test_files = [Path(root, file) for file in files]
             test_files = filter(lambda file: self.is_test_file(file.name), test_files)
             for test_file in test_files:
                 yield test_file

--- a/src/commands/test/collector.py
+++ b/src/commands/test/collector.py
@@ -1,6 +1,8 @@
+from typing import Generator
 import os
 from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import List, Optional, Pattern
 
 from starkware.cairo.lang.compiler.preprocessor.preprocessor_error import (
@@ -18,8 +20,19 @@ class CollectionError(Exception):
 
 @dataclass
 class TestCollector:
-    sources_directory: Path
+    target: Path
     include_paths: Optional[List[str]] = None
+    target_function: Optional[str] = None
+    test_filename_re = [
+            re.compile(r'^test_.*\.cairo'),
+            re.compile(r'^.*_test.cairo')
+        ]
+
+    def __post_init__(self):
+        if re.match(r"^.*\.cairo::.*", self.target.name):
+            file_name, self.target_function = self.target.name.split("::")
+            self.target = self.target.parent / file_name
+            assert not self.target.is_dir()
 
     # TODO: Optimize, by returning preprocessed test program, for reuse when compiling it for test runs
     def collect(
@@ -27,34 +40,41 @@ class TestCollector:
         match_pattern: Optional[Pattern] = None,
         omit_pattern: Optional[Pattern] = None,
     ) -> List[TestSubject]:
-        test_sources = []
-        for root, _, files in os.walk(self.sources_directory):
-            test_files = [
-                file
-                for file in files
-                if file.endswith(".cairo")
-                and (file.startswith("test_") or file.endswith("_test.cairo"))
-            ]
-            for test_file_name in test_files:
-                test_file_path = Path(root, test_file_name)
-                test_file_path = test_file_path.resolve()
 
-                if match_pattern and not match_pattern.match(str(test_file_path)):
-                    continue
-                if omit_pattern and omit_pattern.match(str(test_file_path)):
-                    continue
-
-                test_functions = self._collect_test_functions(test_file_path)
-                if not test_functions:
-                    continue
-
-                test_sources.append(
-                    TestSubject(
-                        test_path=test_file_path,
+        test_files = self.get_test_files()
+        
+        if match_pattern:
+            test_files = filter(lambda file: match_pattern.match(file.name), test_files)
+        if omit_pattern:
+            test_files = filter(lambda file: not omit_pattern.match(file.name), test_files) 
+        
+        test_files = map(self.build_test_subject, test_files)
+        non_empty = filter(lambda file: (file.test_functions) != [], test_files )
+        return list(non_empty)
+    
+    def build_test_subject(self, file_path: Path):
+        test_functions = self._collect_test_functions(file_path)
+        if self.target_function:
+            test_functions = [f for f in test_functions if f['name'] == self.target_function]
+        return TestSubject(
+                        test_path=file_path,
                         test_functions=test_functions,
                     )
-                )
-        return test_sources
+
+    def get_test_files(self) -> Generator[Path, None, None]:        
+        if not self.target.is_dir():
+            yield self.target
+            return
+        for root, _, files in os.walk(self.target):
+            test_files = map(lambda file: Path(root, file), files)
+            test_files = filter(lambda file: self.is_test_file(file.name), test_files)
+            for test_file in test_files:
+                yield test_file
+
+    @classmethod
+    def is_test_file(cls, filename: str) -> bool:
+        return any(test_re.match(filename) for test_re in cls.test_filename_re)
+
 
     def _collect_test_functions(self, file_path: Path) -> List[dict]:
         try:

--- a/src/commands/test/collector_test.py
+++ b/src/commands/test/collector_test.py
@@ -7,16 +7,21 @@ from src.commands.test.collector import TestCollector, CollectionError
 
 current_directory = Path(__file__).parent
 
+def test_is_test_file():
+    assert not TestCollector.is_test_file("ex.cairo")
+    assert TestCollector.is_test_file("ex_test.cairo")
+    assert TestCollector.is_test_file("test_ex.cairo")
+    assert not TestCollector.is_test_file("z_test_ex.cairo")
 
 def test_matching_pattern():
-    match_pattern = re.compile(".*nested/test_basic.*")
+    match_pattern = re.compile("test_basic.*")
     collector = TestCollector(
-        sources_directory=Path(current_directory, "examples"),
+        target=Path(current_directory, "examples"),
         include_paths=[str(Path(current_directory, "examples"))],
     )
     subjects = collector.collect(match_pattern=match_pattern)
     test_names = [subject.test_path.name for subject in subjects]
-    assert test_names == ["test_basic.cairo"]
+    assert set(test_names) == set(["test_basic.cairo", "test_basic_broken.cairo", "test_basic_failure.cairo"])
 
 
 def test_omitting_pattern():
@@ -24,27 +29,48 @@ def test_omitting_pattern():
         "test_basic_broken.cairo",
         "test_basic_failure.cairo",
         "test_basic.cairo",
+        "test_proxy.cairo",
+        "test_cheats.cairo"
     ]
     omit_pattern = re.compile(".*invalid.*")
     collector = TestCollector(
-        sources_directory=Path(current_directory, "examples"),
+        target=Path(current_directory, "examples"),
         include_paths=[str(Path(current_directory, "examples"))],
     )
     subjects = collector.collect(omit_pattern=omit_pattern)
     test_names = [subject.test_path.name for subject in subjects]
-    for test_name in should_collect:
-        assert test_name in test_names
+
+    assert set(test_names) == set(should_collect)
 
     assert "test_invalid_syntax.cairo" not in test_names
     assert "test_no_test_functions.cairo" not in test_names
 
 
 def test_breakage_upon_broken_test_file():
-    match_pattern = re.compile(".*invalid/test_invalid_syntax.*")
+    match_pattern = re.compile("test_invalid_syntax.*")
     collector = TestCollector(
-        sources_directory=Path(current_directory, "examples"),
+        target=Path(current_directory, "examples", "invalid"),
         include_paths=[str(Path(current_directory, "examples"))],
     )
 
     with pytest.raises(CollectionError):
         collector.collect(match_pattern=match_pattern)
+
+def test_collect_specific_file():
+    collector = TestCollector(
+        target=Path(current_directory, "examples", "nested" ,"test_basic.cairo"),
+        include_paths=[str(Path(current_directory, "examples"))],
+    )
+    subjects = collector.collect()
+    test_names = [subject.test_path.name for subject in subjects]
+    assert test_names == ["test_basic.cairo"]
+
+def test_collect_specific_function():
+    collector = TestCollector(
+        target=Path(current_directory, "examples", "nested" ,"test_basic.cairo::test_call_not_deployed"),
+        include_paths=[str(Path(current_directory, "examples"))],
+    )
+    subjects = collector.collect()
+    test_names = [subject.test_path.name for subject in subjects]
+    assert test_names == ["test_basic.cairo"]
+    assert len(subjects[0].test_functions) == 1

--- a/src/commands/test/collector_test.py
+++ b/src/commands/test/collector_test.py
@@ -7,11 +7,13 @@ from src.commands.test.collector import TestCollector, CollectionError
 
 current_directory = Path(__file__).parent
 
+
 def test_is_test_file():
     assert not TestCollector.is_test_file("ex.cairo")
     assert TestCollector.is_test_file("ex_test.cairo")
     assert TestCollector.is_test_file("test_ex.cairo")
     assert not TestCollector.is_test_file("z_test_ex.cairo")
+
 
 def test_matching_pattern():
     match_pattern = re.compile("test_basic.*")
@@ -21,7 +23,9 @@ def test_matching_pattern():
     )
     subjects = collector.collect(match_pattern=match_pattern)
     test_names = [subject.test_path.name for subject in subjects]
-    assert set(test_names) == set(["test_basic.cairo", "test_basic_broken.cairo", "test_basic_failure.cairo"])
+    assert set(test_names) == set(
+        ["test_basic.cairo", "test_basic_broken.cairo", "test_basic_failure.cairo"]
+    )
 
 
 def test_omitting_pattern():
@@ -30,7 +34,7 @@ def test_omitting_pattern():
         "test_basic_failure.cairo",
         "test_basic.cairo",
         "test_proxy.cairo",
-        "test_cheats.cairo"
+        "test_cheats.cairo",
     ]
     omit_pattern = re.compile(".*invalid.*")
     collector = TestCollector(
@@ -56,18 +60,25 @@ def test_breakage_upon_broken_test_file():
     with pytest.raises(CollectionError):
         collector.collect(match_pattern=match_pattern)
 
+
 def test_collect_specific_file():
     collector = TestCollector(
-        target=Path(current_directory, "examples", "nested" ,"test_basic.cairo"),
+        target=Path(current_directory, "examples", "nested", "test_basic.cairo"),
         include_paths=[str(Path(current_directory, "examples"))],
     )
     subjects = collector.collect()
     test_names = [subject.test_path.name for subject in subjects]
     assert test_names == ["test_basic.cairo"]
 
+
 def test_collect_specific_function():
     collector = TestCollector(
-        target=Path(current_directory, "examples", "nested" ,"test_basic.cairo::test_call_not_deployed"),
+        target=Path(
+            current_directory,
+            "examples",
+            "nested",
+            "test_basic.cairo::test_call_not_deployed",
+        ),
         include_paths=[str(Path(current_directory, "examples"))],
     )
     subjects = collector.collect()

--- a/src/commands/test/examples/nested/test_basic.cairo
+++ b/src/commands/test/examples/nested/test_basic.cairo
@@ -23,3 +23,16 @@ func test_example{syscall_ptr : felt*, range_check_ptr}():
     BasicContract.increase_balance(contract_address=contract_a_address, amount=15)
     return ()
 end
+
+@external
+func test_call_not_deployed{syscall_ptr : felt*, range_check_ptr}():
+    alloc_locals
+    %{ expect_revert() %}
+
+    local contract_a_address : felt
+    %{ 
+        ids.contract_a_address = 34134124
+    %}
+    BasicContract.increase_balance(contract_address=contract_a_address, amount=15)
+    return ()
+end

--- a/src/commands/test/runner.py
+++ b/src/commands/test/runner.py
@@ -59,7 +59,7 @@ class TestRunner:
         self.reporter = TestReporter(src)
         assert self.include_paths is not None, "Uninitialized paths list in test runner"
         test_subjects = TestCollector(
-            sources_directory=src,
+            target=src,
             include_paths=self.include_paths,
         ).collect(
             match_pattern=match_pattern,


### PR DESCRIPTION
Changes:
- support of a syntax `a/b/c.cairo`
- support of a syntax `a/b/c.cairo::test_function`
- some refactoring
- now match and omit regexes refer to filenames not whole paths

Docs update task:
https://github.com/software-mansion/protostar/issues/133#issue-1191402912