### PR TITLE
Bring back old start_prank docs

### DIFF
--- a/website/docs/tutorials/guides/testing.md
+++ b/website/docs/tutorials/guides/testing.md
@@ -440,7 +440,22 @@ Deploys a contract given a path relative to a Protostar project root. The sectio
 
 
 ### `start_prank`
+```python
+def start_prank(caller_address: int) -> None: ...
+```
 
+Changes caller address until [`stop_prank`](#stop_prank) cheatcode is used.
+
+### `stop_prank`
+
+```python
+def stop_prank() -> None: ...
+```
+
+Resets caller address. Always used with [`start_prank`](#start_prank).
+
+<!-- PROTOSTAR 0.2.1 -->
+<!-- 
 ```python
 def start_prank(caller_address: int, target_contract_address: Optional[int] = None) -> Callable: ...
 ```
@@ -498,7 +513,7 @@ func test_remote_prank{syscall_ptr : felt*, range_check_ptr}():
     return ()
 end
 ``` 
-
+ -->
 
 
 ### `roll`


### PR DESCRIPTION
Currently, deployed docs describe the updated `start_prank`.