### PR TITLE
[globs::01] Add `collect_from_globs` method to `TestCollector`

### DIFF
--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -299,18 +299,23 @@ class TestCollector:
         preprocessed = self._preprocess_contract(test_suite_path)
         collected_test_case_names = set(self._collect_test_case_names(preprocessed))
 
-        target_test_case_names: Set[str] = collected_test_case_names.copy()
+        # gather test cases that match any test case glob
+        target_test_case_names: Set[str] = set()
         for test_case_name in collected_test_case_names:
-            for test_case_glob in test_cases_info.test_case_globs:
-                if not fnmatch(test_case_name, test_case_glob):
-                    target_test_case_names.remove(test_case_name)
-                    break
+            if len(test_cases_info.test_case_globs) == 0:
+                target_test_case_names = collected_test_case_names.copy()
+            else:
+                for test_case_glob in test_cases_info.test_case_globs:
+                    if fnmatch(test_case_name, test_case_glob):
+                        target_test_case_names.add(test_case_name)
 
+        # filter out test cases that match any test case glob
         not_ignored_target_test_case_names = target_test_case_names.copy()
         for test_case_name in target_test_case_names:
             for ignored_test_case_glob in test_cases_info.ignored_test_cases:
                 if fnmatch(test_case_name, ignored_test_case_glob):
                     not_ignored_target_test_case_names.remove(test_case_name)
+                    break
 
         return TestSuite(
             test_path=test_suite_path,

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -233,8 +233,6 @@ class TestCollector:
         results: TestCasesDict = {}
 
         for parsed_target in parsed_targets:
-            if not parsed_target.test_suite_glob:
-                continue
             test_suite_paths = self._find_test_suite_paths_from_glob(
                 parsed_target.test_suite_glob
             )

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -234,17 +234,14 @@ class TestCollector:
         self,
         parsed_targets: Set[ParsedTarget],
     ) -> TestCaseGlobsDict:
-        results: TestCaseGlobsDict = {}
+        results: TestCaseGlobsDict = defaultdict(set)
 
         for parsed_target in parsed_targets:
             test_suite_paths = self._find_test_suite_paths_from_glob(
                 parsed_target.test_suite_glob
             )
             for test_suite_path in test_suite_paths:
-                test_case_globs = results.setdefault(test_suite_path, set())
-                if parsed_target.test_case_glob:
-                    test_case_globs.add(parsed_target.test_case_glob)
-
+                result[test_suite_path].add(parsed_target.test_case_glob)
         return results
 
     def parse_targets(

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -5,7 +5,7 @@ from fnmatch import fnmatch
 from glob import glob
 from logging import Logger
 from pathlib import Path
-from typing import Generator, List, Optional, Pattern, Set, cast
+from typing import Dict, Generator, List, Optional, Pattern, Set, cast
 
 from starkware.cairo.lang.compiler.preprocessor.preprocessor_error import (
     PreprocessorError,
@@ -17,6 +17,19 @@ from starkware.starknet.compiler.starknet_preprocessor import (
 from protostar.commands.test.test_suite import TestSuite
 from protostar.protostar_exception import ProtostarException
 from protostar.utils.starknet_compilation import StarknetCompiler
+
+TestSuiteGlob = str
+TestSuitePath = str
+TestCaseGlob = str
+
+"""e.g. tests/**/::test_*"""
+TestSuiteAndCaseGlob = str
+
+
+@dataclass
+class TestSuiteTarget:
+    target_test_cases: Set[TestCaseGlob]
+    ignored_target_test_cases: Set[TestCaseGlob]
 
 
 class TestCollectingException(ProtostarException):
@@ -51,8 +64,13 @@ class TestCollector:
             else:
                 logger.warning("No cases found")
 
-    def __init__(self, starknet_compiler: StarknetCompiler) -> None:
+    def __init__(
+        self,
+        starknet_compiler: StarknetCompiler,
+        default_test_suite_glob: Optional[str] = None,
+    ) -> None:
         self._starknet_compiler = starknet_compiler
+        self._default_test_suite_glob = default_test_suite_glob
 
     supported_test_suite_filename_patterns = [
         re.compile(r"^test_.*\.cairo"),
@@ -155,89 +173,90 @@ class TestCollector:
         target_globs: List[str],
         ignored_globs: Optional[List[str]] = None,
     ) -> "TestCollector.Result":
-        test_suites: Set[TestSuite] = set()
+        target_test_suite_paths_to_test_case_globs = (
+            self.normalize_test_suite_and_case_globs(set(target_globs))
+        )
+        ignored_target_test_suite_paths_to_test_case_globs = (
+            self.normalize_test_suite_and_case_globs(set(ignored_globs or []))
+        )
 
-        # extract ignored globs that target test_case
-        ignored_test_suite_globs: Set[str] = set()
-        ignored_test_suite_and_test_case_globs: Set[str] = set()
-
-        if ignored_globs:
-            for ignored_glob in ignored_globs:
-                if "::" in ignored_glob:
-                    ignored_test_suite_and_test_case_globs.add(ignored_glob)
-                else:
-                    ignored_test_suite_globs.add(ignored_glob)
-
-        # find ignored test suite filepaths
-        ignored_test_suite_filepaths: Set[str] = set()
-        for ignored_test_suite_glob in ignored_test_suite_globs:
-            ignored_test_suite_filepaths.update(
-                self._find_test_suite_filepaths_from_glob(ignored_test_suite_glob)
+        test_suite_path_to_test_suite_target = (
+            self.combine_normalized_target_and_ignored_globs(
+                target_test_suite_paths_to_test_case_globs,
+                ignored_target_test_suite_paths_to_test_case_globs,
             )
-
-        for target_glob in target_globs:
-            target_test_suites = self._collect_from_glob(
-                target_glob,
-                ignored_test_suite_filepaths,
-                ignored_test_suite_and_test_case_globs,
-            )
-
-            test_suites.update(target_test_suites)
-
-        return TestCollector.Result(
-            test_suites=list(test_suites),
         )
 
-    def _collect_from_glob(
-        self,
-        target_glob: str,
-        ignored_test_suite_filepaths: Set[str],
-        ignored_test_suite_and_test_case_globs: Set[str],
-    ) -> Set[TestSuite]:
-        # extract target_test_case_glob
-        target_test_case_glob: Optional[str] = None
-        target_test_suite_glob = target_glob
-        if "::" in target_glob:
-            target_test_suite_glob, target_test_case_glob = target_glob.split("::")
-
-        # find test suites from target
-        potential_test_suite_filepaths = self._find_test_suite_filepaths_from_glob(
-            target_test_suite_glob
-        )
-
-        # filter out ignored test suites
-        filtered_test_suite_filepaths = (
-            potential_test_suite_filepaths - ignored_test_suite_filepaths
-        )
-
-        # create TestSuite objects
         test_suites: List[TestSuite] = []
-        for test_suite_filepath in filtered_test_suite_filepaths:
-            # find ignored test case globs for this test suite
-            ignored_test_case_globs: Set[str] = set()
-            for (
-                ignored_test_suite_and_test_case_glob
-            ) in ignored_test_suite_and_test_case_globs:
-                (
-                    _,
-                    ignored_test_case_glob,
-                ) = ignored_test_suite_and_test_case_glob.split("::")
-                ignored_test_case_globs.add(ignored_test_case_glob)
-
+        for (
+            test_suite_path,
+            test_suite,
+        ) in test_suite_path_to_test_suite_target.items():
             test_suites.append(
-                self._build_test_suite_from_test_case_glob(
-                    Path(test_suite_filepath),
-                    target_test_case_glob,
-                    ignored_test_case_globs,
+                self._build_test_suite_from_test_target(
+                    Path(test_suite_path),
+                    test_suite,
                 )
             )
 
-        # filter out empty test suites
-        non_empty_test_suites = set(
-            filter(lambda test_file: (test_file.test_case_names) != [], test_suites)
+        return TestCollector.Result(
+            test_suites=test_suites,
         )
 
-        return non_empty_test_suites
+    def normalize_test_suite_and_case_globs(
+        self,
+        test_suite_and_case_globs: Set[TestSuiteAndCaseGlob],
+    ) -> Dict[TestSuitePath, Set[TestCaseGlob]]:
+        results: Dict[TestSuitePath, Set[TestCaseGlob]] = {}
+
+        for test_suite_and_case_glob in test_suite_and_case_globs:
+            test_suite_glob: Optional[TestSuiteGlob] = test_suite_and_case_glob
+            test_case_glob: Optional[TestCaseGlob] = None
+            if "::" in test_suite_and_case_glob:
+                (test_suite_glob, test_case_glob) = test_suite_and_case_glob.split("::")
+            test_suite_glob = test_suite_glob or self._default_test_suite_glob
+            if not test_suite_glob:
+                continue
+
+            test_suite_paths = self._find_test_suite_filepaths_from_glob(
+                test_suite_glob
+            )
+            for test_suite_path in test_suite_paths:
+                test_case_globs = results.setdefault(test_suite_path, set())
+                if test_case_glob:
+                    test_case_globs.add(test_case_glob)
+
+        return results
+
+    def combine_normalized_target_and_ignored_globs(
+        self,
+        targets: Dict[TestSuitePath, Set[TestCaseGlob]],
+        ignored_targets: Dict[TestSuitePath, Set[TestCaseGlob]],
+    ) -> Dict[TestSuitePath, TestSuiteTarget]:
+        filtered_targets = targets
+        for ignored_target_path in ignored_targets:
+            if (
+                len(ignored_targets[ignored_target_path]) == 0
+                and ignored_target_path in filtered_targets
+            ):
+                del filtered_targets[ignored_target_path]
+
+        result: Dict[TestSuitePath, TestSuiteTarget] = {}
+
+        for target_path in filtered_targets:
+            test_suite_target = result.setdefault(
+                target_path,
+                TestSuiteTarget(
+                    target_test_cases=set(), ignored_target_test_cases=set()
+                ),
+            )
+            test_suite_target.target_test_cases = filtered_targets[target_path]
+            if target_path in ignored_targets:
+                test_suite_target.ignored_target_test_cases = ignored_targets[
+                    target_path
+                ]
+
+        return result
 
     def _find_test_suite_filepaths_from_glob(self, test_suite_glob: str) -> Set[str]:
         results: Set[str] = set()
@@ -259,34 +278,30 @@ class TestCollector:
                 results.add(filepath)
         return results
 
-    def _build_test_suite_from_test_case_glob(
+    def _build_test_suite_from_test_target(
         self,
         test_suite_path: Path,
-        target_test_case_glob: Optional[str],
-        ignored_test_case_globs: Set[str],
+        test_suite_target: TestSuiteTarget,
     ) -> TestSuite:
         preprocessed = self._preprocess_contract(test_suite_path)
         collected_test_case_names = set(self._collect_test_case_names(preprocessed))
 
-        test_case_names = collected_test_case_names
-        if target_test_case_glob:
-            test_case_names = set()
-            for collected_test_case_name in collected_test_case_names:
-                if fnmatch(collected_test_case_name, target_test_case_glob):
-                    test_case_names.add(collected_test_case_name)
+        target_test_case_names: Set[str] = collected_test_case_names.copy()
+        for test_case_name in collected_test_case_names:
+            for test_case_glob in test_suite_target.target_test_cases:
+                if not fnmatch(test_case_name, test_case_glob):
+                    target_test_case_names.remove(test_case_name)
+                    break
 
-        filtered_test_case_names: Set[str] = set()
-        for test_case_name in test_case_names:
-            if len(ignored_test_case_globs) == 0:
-                filtered_test_case_names = test_case_names
-            else:
-                for ignored_test_case_glob in ignored_test_case_globs:
-                    if not fnmatch(test_case_name, ignored_test_case_glob):
-                        filtered_test_case_names.add(test_case_name)
+        not_ignored_target_test_case_names = target_test_case_names.copy()
+        for test_case_name in target_test_case_names:
+            for ignored_test_case_glob in test_suite_target.ignored_target_test_cases:
+                if fnmatch(test_case_name, ignored_test_case_glob):
+                    not_ignored_target_test_case_names.remove(test_case_name)
 
         return TestSuite(
             test_path=test_suite_path,
-            test_case_names=list(filtered_test_case_names),
+            test_case_names=list(not_ignored_target_test_case_names),
             preprocessed_contract=preprocessed,
             setup_fn_name=self._find_setup_hook_name(preprocessed),
         )

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -213,10 +213,12 @@ class TestCollector:
             target_test_cases_info_dict
         )
 
-        # TODO: filter out empty test suites
+        non_empty_test_suites = list(
+            filter(lambda test_file: (test_file.test_case_names) != [], test_suites)
+        )
 
         return TestCollector.Result(
-            test_suites=test_suites,
+            test_suites=non_empty_test_suites,
         )
 
     def build_test_cases_dict(

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -7,10 +7,12 @@ from logging import Logger
 from pathlib import Path
 from typing import Generator, List, Optional, Pattern, Set, cast
 
-from starkware.cairo.lang.compiler.preprocessor.preprocessor_error import \
-    PreprocessorError
-from starkware.starknet.compiler.starknet_preprocessor import \
-    StarknetPreprocessedProgram
+from starkware.cairo.lang.compiler.preprocessor.preprocessor_error import (
+    PreprocessorError,
+)
+from starkware.starknet.compiler.starknet_preprocessor import (
+    StarknetPreprocessedProgram,
+)
 
 from protostar.commands.test.test_suite import TestSuite
 from protostar.protostar_exception import ProtostarException
@@ -88,7 +90,7 @@ class TestCollector:
             test_suites=non_empty_test_suites,
         )
 
-    def collect_from_glob_targets(
+    def collect_from_globs(
         self,
         glob_targets: List[str],
         omit_pattern: Optional[Pattern] = None,
@@ -119,7 +121,9 @@ class TestCollector:
             test_suites: List[TestSuite] = []
             for test_suite in test_suite_filepaths:
                 test_suites.append(
-                    self._build_test_suite_from_test_case_glob(Path(test_suite), target_test_case_glob)
+                    self._build_test_suite_from_test_case_glob(
+                        Path(test_suite), target_test_case_glob
+                    )
                 )
 
             non_empty_test_suites = list(

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -287,7 +287,9 @@ class TestCollector:
                 )
         return result
 
-    def _find_test_suite_paths_from_glob(self, test_suite_glob: str) -> Set[Path]:
+    def _find_test_suite_paths_from_glob(
+        self, test_suite_glob: str
+    ) -> Set[TestSuitePath]:
         results: Set[Path] = set()
         matches = glob(test_suite_glob, recursive=True)
         for match in matches:
@@ -299,7 +301,7 @@ class TestCollector:
         return results
 
     # pylint: disable=no-self-use
-    def _find_test_suite_paths_in_dir(self, path: Path) -> Set[Path]:
+    def _find_test_suite_paths_in_dir(self, path: Path) -> Set[TestSuitePath]:
         filepaths = set(glob(f"{path}/**/*.cairo", recursive=True))
         results: Set[Path] = set()
         for filepath in filepaths:

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -92,17 +92,17 @@ class TestCollector:
 
     def collect_from_globs(
         self,
-        glob_targets: List[str],
+        target_globs: List[str],
         omit_pattern: Optional[Pattern] = None,
     ) -> "TestCollector.Result":
 
         unique_test_suites: Set[TestSuite] = set()
-        for glob_target in glob_targets:
+        for target_glob in target_globs:
             test_suite_filepaths: Set[str] = set()
             target_test_case_glob: Optional[str] = None
-            valid_glob = glob_target
-            if re.match(r"^.*\.cairo::.*", glob_target):
-                valid_glob, target_test_case_glob = glob_target.split("::")
+            valid_glob = target_glob
+            if re.match(r"^.*\.cairo::.*", target_glob):
+                valid_glob, target_test_case_glob = target_glob.split("::")
 
             test_suite_filepaths.update(
                 self._find_test_suite_filepaths_from_glob(valid_glob)
@@ -136,9 +136,9 @@ class TestCollector:
             test_suites=list(unique_test_suites),
         )
 
-    def _find_test_suite_filepaths_from_glob(self, glob_target: str) -> Set[str]:
+    def _find_test_suite_filepaths_from_glob(self, target_glob: str) -> Set[str]:
         results: Set[str] = set()
-        matches = glob(glob_target, recursive=True)
+        matches = glob(target_glob, recursive=True)
         for match in matches:
             path = Path(match)
             if path.is_dir():

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -150,14 +150,11 @@ class TestCollector:
             print(p_err)
             raise TestCollectingException("Failed to collect test cases") from p_err
 
-    # GLOBS
-
     def collect_from_globs(
         self,
         target_globs: List[str],
         ignored_globs: Optional[List[str]] = None,
     ) -> "TestCollector.Result":
-
         test_suites: Set[TestSuite] = set()
 
         # extract ignored globs that target test_case
@@ -291,5 +288,5 @@ class TestCollector:
             test_path=test_suite_path,
             test_case_names=list(filtered_test_case_names),
             preprocessed_contract=preprocessed,
-            setup_state_fn_name=self._find_setup_state_hook_name(preprocessed),
+            setup_fn_name=self._find_setup_hook_name(preprocessed),
         )

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -27,8 +27,8 @@ class TestCollector:
     class Result:
         def __init__(self, test_suites: List[TestSuite]) -> None:
             self.test_suites = test_suites
-            self.test_cases_count = (
-                sum([len(test_suite.test_case_names) for test_suite in test_suites]),
+            self.test_cases_count = sum(
+                [len(test_suite.test_case_names) for test_suite in test_suites]
             )
 
         def log(self, logger: Logger):
@@ -94,16 +94,15 @@ class TestCollector:
     ) -> "TestCollector.Result":
         test_suite_filepaths: Set[str] = set()
         for glob_target in glob_targets:
-            if not glob_target.endswith(".cairo"):
-                matches = glob(glob_target, recursive=True)
-                for match in matches:
-                    path = Path(match)
-                    if path.is_dir():
-                        test_suite_filepaths.update(
-                            self._find_test_suite_filepaths_in_dir(path)
-                        )
-                    elif path.is_file() and TestCollector.is_test_suite(path.name):
-                        test_suite_filepaths.add(str(path))
+            matches = glob(glob_target, recursive=True)
+            for match in matches:
+                path = Path(match)
+                if path.is_dir():
+                    test_suite_filepaths.update(
+                        self._find_test_suite_filepaths_in_dir(path)
+                    )
+                elif path.is_file() and TestCollector.is_test_suite(path.name):
+                    test_suite_filepaths.add(match)
 
         test_suites: List[TestSuite] = []
         for test_suite in test_suite_filepaths:

--- a/protostar/commands/test/test_collector.py
+++ b/protostar/commands/test/test_collector.py
@@ -188,13 +188,13 @@ class TestCollector:
             print(p_err)
             raise TestCollectingException("Failed to collect test cases") from p_err
 
-    def collect_from_globs(
+    def collect_from_targets(
         self,
-        globs: List[str],
-        ignored_globs: Optional[List[str]] = None,
+        targets: List[Target],
+        ignored_targets: Optional[List[Target]] = None,
     ) -> "TestCollector.Result":
-        parsed_targets = self.parse_targets(set(globs))
-        ignored_parsed_targets = self.parse_targets(set(ignored_globs or []))
+        parsed_targets = self.parse_targets(set(targets))
+        ignored_parsed_targets = self.parse_targets(set(ignored_targets or []))
 
         test_cases_dict = self.build_test_cases_dict(parsed_targets)
         ignored_test_cases_dict = self.build_test_cases_dict(ignored_parsed_targets)

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -229,7 +229,7 @@ def test_logging_no_cases_found(mocker: MockerFixture):
 def test_collecting_from_directory_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_glob_targets(
+    result = test_collector.collect_from_globs(
         [f"{project_root}/b*r", f"{project_root}/f*"]
     )
 
@@ -239,9 +239,7 @@ def test_collecting_from_directory_globs(starknet_compiler, project_root):
 def test_recursive_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_glob_targets(
-        [f"{project_root}/**/test_foo.cairo"]
-    )
+    result = test_collector.collect_from_globs([f"{project_root}/**/test_foo.cairo"])
 
     assert_tested_suites(result.test_suites, ["test_foo.cairo", "test_foo.cairo"])
 
@@ -249,7 +247,7 @@ def test_recursive_globs(starknet_compiler, project_root):
 def test_collecting_specific_function_in_glob(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_glob_targets(
+    result = test_collector.collect_from_globs(
         [f"{project_root}/**/test_foo.cairo::test_case_a"]
     )
 
@@ -263,7 +261,7 @@ def test_collecting_specific_function_in_glob(starknet_compiler, project_root):
 def test_multiple_globs_pointing_to_test_case(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_glob_targets(
+    result = test_collector.collect_from_globs(
         [
             f"{project_root}/foo/test_foo.cairo::test_case_a",
             f"{project_root}/**/bar_test.cairo::test_case_a",
@@ -280,7 +278,7 @@ def test_multiple_globs_pointing_to_test_case(starknet_compiler, project_root):
 def test_omitting_pattern_in_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_glob_targets(
+    result = test_collector.collect_from_globs(
         [str(project_root)], omit_pattern=re.compile(".*foo.*")
     )
 
@@ -291,7 +289,7 @@ def test_omitting_pattern_in_globs(starknet_compiler, project_root):
 def test_globs_in_test_case_name(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_glob_targets(
+    result = test_collector.collect_from_globs(
         [f"{project_root}/foo/test_foo.cairo::*b"]
     )
 

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -324,3 +324,15 @@ def test_ignoring_test_cases(starknet_compiler, project_root: Path):
     assert_tested_suites(result.test_suites, ["test_foo.cairo"])
     assert result.test_cases_count == 1
     assert result.test_suites[0].test_case_names[0] == "test_case_b"
+
+
+def test_empty_test_suites(starknet_compiler, project_root: Path):
+    test_collector = TestCollector(
+        starknet_compiler, default_test_suite_glob=str(project_root)
+    )
+
+    result = test_collector.collect_from_globs(
+        [f"{project_root}/foo/test_foo.cairo::test_not_existing_test_case"],
+    )
+
+    assert_tested_suites(result.test_suites, [])

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -298,8 +298,10 @@ def test_globs_in_test_case_name(starknet_compiler, project_root):
     assert result.test_suites[0].test_case_names[0] == "test_case_b"
 
 
-def test_ignoring_test_cases(starknet_compiler, project_root):
-    test_collector = TestCollector(starknet_compiler)
+def test_ignoring_test_cases(starknet_compiler, project_root: Path):
+    test_collector = TestCollector(
+        starknet_compiler, default_test_suite_glob=str(project_root)
+    )
 
     result = test_collector.collect_from_globs(
         [f"{project_root}/foo/test_foo.cairo"], ignored_globs=["::test_case_a"]

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -314,11 +314,13 @@ def test_combining_test_suites(starknet_compiler, project_root):
 
 def test_ignoring_test_cases(starknet_compiler, project_root: Path):
     test_collector = TestCollector(
-        starknet_compiler, default_test_suite_glob=str(project_root)
+        starknet_compiler,
     )
 
     result = test_collector.collect_from_targets(
-        [f"{project_root}/foo/test_foo.cairo"], ignored_targets=["::test_case_a"]
+        [f"{project_root}/foo/test_foo.cairo"],
+        ignored_targets=["::test_case_a"],
+        default_test_suite_glob=str(project_root),
     )
 
     assert_tested_suites(result.test_suites, ["test_foo.cairo"])
@@ -327,12 +329,26 @@ def test_ignoring_test_cases(starknet_compiler, project_root: Path):
 
 
 def test_empty_test_suites(starknet_compiler, project_root: Path):
-    test_collector = TestCollector(
-        starknet_compiler, default_test_suite_glob=str(project_root)
-    )
+    test_collector = TestCollector(starknet_compiler)
 
     result = test_collector.collect_from_targets(
         [f"{project_root}/foo/test_foo.cairo::test_not_existing_test_case"],
     )
 
     assert_tested_suites(result.test_suites, [])
+
+
+def test_testing_all_test_cases_despite_one_of_points_to_specific_test_case(
+    starknet_compiler, project_root: Path
+):
+    test_collector = TestCollector(starknet_compiler)
+
+    result = test_collector.collect_from_targets(
+        [
+            f"{project_root}/foo/test_foo.cairo",
+            f"{project_root}/foo/test_foo.cairo::test_case_a",
+        ],
+    )
+
+    assert_tested_suites(result.test_suites, ["test_foo.cairo"])
+    assert result.test_cases_count == 2

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -286,3 +286,15 @@ def test_omitting_pattern_in_globs(starknet_compiler, project_root):
 
     assert_tested_suites(result.test_suites, ["bar_test.cairo"])
     assert result.test_cases_count == 2
+
+
+def test_globs_in_test_case_name(starknet_compiler, project_root):
+    test_collector = TestCollector(starknet_compiler)
+
+    result = test_collector.collect_from_glob_targets(
+        [f"{project_root}/foo/test_foo.cairo::*b"]
+    )
+
+    assert_tested_suites(result.test_suites, ["test_foo.cairo"])
+    assert result.test_cases_count == 1
+    assert result.test_suites[0].test_case_names[0] == "test_case_b"

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -298,6 +298,20 @@ def test_globs_in_test_case_name(starknet_compiler, project_root):
     assert result.test_suites[0].test_case_names[0] == "test_case_b"
 
 
+def test_combining_test_suites(starknet_compiler, project_root):
+    test_collector = TestCollector(starknet_compiler)
+
+    result = test_collector.collect_from_globs(
+        [
+            f"{project_root}/foo/test_foo.cairo::*a",
+            f"{project_root}/foo/test_foo.cairo::*b",
+        ]
+    )
+
+    assert_tested_suites(result.test_suites, ["test_foo.cairo"])
+    assert result.test_cases_count == 2
+
+
 def test_ignoring_test_cases(starknet_compiler, project_root: Path):
     test_collector = TestCollector(
         starknet_compiler, default_test_suite_glob=str(project_root)

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -131,7 +131,6 @@ def test_logging_collected_one_test_suite_and_one_test_case(mocker: MockerFixtur
                 preprocessed_contract=mocker.MagicMock(),
             )
         ],
-        test_cases_count=1,
     ).log(logger_mock)
 
     cast(MagicMock, logger_mock.info).assert_called_once_with(
@@ -155,7 +154,6 @@ def test_logging_many_test_suites_and_many_test_cases(mocker: MockerFixture):
                 preprocessed_contract=mocker.MagicMock(),
             ),
         ],
-        test_cases_count=2,
     ).log(logger_mock)
 
     cast(MagicMock, logger_mock.info).assert_called_once_with(
@@ -168,7 +166,16 @@ def test_logging_no_cases_found(mocker: MockerFixture):
 
     TestCollector.Result(
         test_suites=[],
-        test_cases_count=0,
     ).log(logger_mock)
 
     cast(MagicMock, logger_mock.warning).assert_called_once_with("No cases found")
+
+
+def test_collecting_from_directory_globs(starknet_compiler, project_root):
+    test_collector = TestCollector(starknet_compiler)
+
+    result = test_collector.collect_from_glob_targets(
+        [f"{project_root}/b*", f"{project_root}/f*"]
+    )
+
+    assert_tested_suites(result.test_suites, ["bar_test.cairo", "test_foo.cairo"])

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -229,7 +229,7 @@ def test_logging_no_cases_found(mocker: MockerFixture):
 def test_collecting_from_directory_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs(
+    result = test_collector.collect_from_targets(
         [f"{project_root}/b*r", f"{project_root}/f*"]
     )
 
@@ -239,7 +239,7 @@ def test_collecting_from_directory_globs(starknet_compiler, project_root):
 def test_recursive_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs([f"{project_root}/**/test_foo.cairo"])
+    result = test_collector.collect_from_targets([f"{project_root}/**/test_foo.cairo"])
 
     assert_tested_suites(result.test_suites, ["test_foo.cairo", "test_foo.cairo"])
 
@@ -247,7 +247,7 @@ def test_recursive_globs(starknet_compiler, project_root):
 def test_collecting_specific_function_in_glob(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs(
+    result = test_collector.collect_from_targets(
         [f"{project_root}/**/test_foo.cairo::test_case_a"]
     )
 
@@ -261,7 +261,7 @@ def test_collecting_specific_function_in_glob(starknet_compiler, project_root):
 def test_multiple_globs_pointing_to_test_case(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs(
+    result = test_collector.collect_from_targets(
         [
             f"{project_root}/foo/test_foo.cairo::test_case_a",
             f"{project_root}/**/bar_test.cairo::test_case_a",
@@ -278,8 +278,8 @@ def test_multiple_globs_pointing_to_test_case(starknet_compiler, project_root):
 def test_omitting_pattern_in_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs(
-        [str(project_root)], ignored_globs=[f"{project_root}/**/test_foo.cairo"]
+    result = test_collector.collect_from_targets(
+        [str(project_root)], ignored_targets=[f"{project_root}/**/test_foo.cairo"]
     )
 
     assert_tested_suites(result.test_suites, ["bar_test.cairo"])
@@ -289,7 +289,7 @@ def test_omitting_pattern_in_globs(starknet_compiler, project_root):
 def test_globs_in_test_case_name(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs(
+    result = test_collector.collect_from_targets(
         [f"{project_root}/foo/test_foo.cairo::*b"]
     )
 
@@ -301,7 +301,7 @@ def test_globs_in_test_case_name(starknet_compiler, project_root):
 def test_combining_test_suites(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
-    result = test_collector.collect_from_globs(
+    result = test_collector.collect_from_targets(
         [
             f"{project_root}/foo/test_foo.cairo::*a",
             f"{project_root}/foo/test_foo.cairo::*b",
@@ -317,8 +317,8 @@ def test_ignoring_test_cases(starknet_compiler, project_root: Path):
         starknet_compiler, default_test_suite_glob=str(project_root)
     )
 
-    result = test_collector.collect_from_globs(
-        [f"{project_root}/foo/test_foo.cairo"], ignored_globs=["::test_case_a"]
+    result = test_collector.collect_from_targets(
+        [f"{project_root}/foo/test_foo.cairo"], ignored_targets=["::test_case_a"]
     )
 
     assert_tested_suites(result.test_suites, ["test_foo.cairo"])
@@ -331,7 +331,7 @@ def test_empty_test_suites(starknet_compiler, project_root: Path):
         starknet_compiler, default_test_suite_glob=str(project_root)
     )
 
-    result = test_collector.collect_from_globs(
+    result = test_collector.collect_from_targets(
         [f"{project_root}/foo/test_foo.cairo::test_not_existing_test_case"],
     )
 

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -30,10 +30,22 @@ def test_suites_fixture(project_root: Path):
         - foo
             - test_foo.cairo
             - foo.cairo
+        - baz
+            - foo
+                - test_foo.cairo
+                - foo.cairo
     """
     tmp_bar_path = project_root / "bar"
     tmp_bar_path.mkdir(exist_ok=True, parents=True)
     (tmp_bar_path / "bar_test.cairo").touch()
+
+    tmp_foo_path = project_root / "foo"
+    tmp_foo_path.mkdir(exist_ok=True, parents=True)
+    (tmp_foo_path / "test_foo.cairo").touch()
+    (tmp_foo_path / "foo.cairo").touch()
+
+    tmp_baz_path = project_root / "baz"
+    tmp_baz_path.mkdir(exist_ok=True, parents=True)
     tmp_foo_path = project_root / "foo"
     tmp_foo_path.mkdir(exist_ok=True, parents=True)
     (tmp_foo_path / "test_foo.cairo").touch()
@@ -179,3 +191,13 @@ def test_collecting_from_directory_globs(starknet_compiler, project_root):
     )
 
     assert_tested_suites(result.test_suites, ["bar_test.cairo", "test_foo.cairo"])
+
+
+def test_recursive_globs(starknet_compiler, project_root):
+    test_collector = TestCollector(starknet_compiler)
+
+    result = test_collector.collect_from_glob_targets(
+        [f"{project_root}/**/test_foo.cairo"]
+    )
+
+    assert_tested_suites(result.test_suites, ["test_foo.cairo", "test_foo.cairo"])

--- a/protostar/commands/test/test_collector_test.py
+++ b/protostar/commands/test/test_collector_test.py
@@ -279,7 +279,7 @@ def test_omitting_pattern_in_globs(starknet_compiler, project_root):
     test_collector = TestCollector(starknet_compiler)
 
     result = test_collector.collect_from_globs(
-        [str(project_root)], omit_pattern=re.compile(".*foo.*")
+        [str(project_root)], ignored_globs=[f"{project_root}/**/test_foo.cairo"]
     )
 
     assert_tested_suites(result.test_suites, ["bar_test.cairo"])
@@ -291,6 +291,18 @@ def test_globs_in_test_case_name(starknet_compiler, project_root):
 
     result = test_collector.collect_from_globs(
         [f"{project_root}/foo/test_foo.cairo::*b"]
+    )
+
+    assert_tested_suites(result.test_suites, ["test_foo.cairo"])
+    assert result.test_cases_count == 1
+    assert result.test_suites[0].test_case_names[0] == "test_case_b"
+
+
+def test_ignoring_test_cases(starknet_compiler, project_root):
+    test_collector = TestCollector(starknet_compiler)
+
+    result = test_collector.collect_from_globs(
+        [f"{project_root}/foo/test_foo.cairo"], ignored_globs=["::test_case_a"]
     )
 
     assert_tested_suites(result.test_suites, ["test_foo.cairo"])

--- a/protostar/commands/test/test_suite.py
+++ b/protostar/commands/test/test_suite.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
+
 from starkware.starknet.compiler.starknet_preprocessor import (
     StarknetPreprocessedProgram,
 )
@@ -11,3 +12,6 @@ class TestSuite:
     test_path: Path
     preprocessed_contract: StarknetPreprocessedProgram
     test_case_names: List[str]
+
+    def __hash__(self) -> int:
+        return hash(str(self.test_path) + str(set(self.test_case_names)))

--- a/protostar/commands/test/test_suite.py
+++ b/protostar/commands/test/test_suite.py
@@ -13,10 +13,3 @@ class TestSuite:
     preprocessed_contract: StarknetPreprocessedProgram
     test_case_names: List[str]
     setup_fn_name: Optional[str] = None
-
-    def __hash__(self) -> int:
-        return hash(
-            str(self.test_path)
-            + str(set(self.test_case_names))
-            + str(self.setup_fn_name)
-        )


### PR DESCRIPTION
Extended `TestCollector` to search and ignore, `test_suites` and `test_cases` by globs.
(This PR doesn't change the test command's interface.)

--- 

1. map `test_suite_glob::test_case_glob` to `List[test_suite_path::test_case_glob]` for `target` and `ignore`
2. combine `test_case_globs` in `Mapping[test_case_path, Set[test_case_glob]]` for `target` and `ignore`
3. subtract from target ignored paths
4. build `TestSuite` from target and ignored test case globs for the specific test suite
5. ...