### PR TITLE
Fix `list assignment index out of range`

### DIFF
--- a/protostar/commands/test/cheatcodes/deploy_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/deploy_cheatcode.py
@@ -3,13 +3,11 @@ from dataclasses import dataclass
 from typing import Any, Callable, List
 
 from starkware.python.utils import to_bytes
+from starkware.starknet.business_logic.execution.objects import CallInfo
 from starkware.starknet.core.os.syscall_utils import initialize_contract_state
 
 from protostar.commands.test.cheatcodes.cheatcode import Cheatcode
 from protostar.commands.test.cheatcodes.prepare_cheatcode import PreparedContract
-from starkware.starknet.business_logic.execution.objects import (
-    CallInfo,
-)
 
 
 @dataclass(frozen=True)

--- a/protostar/commands/test/cheatcodes/deploy_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/deploy_cheatcode.py
@@ -1,12 +1,15 @@
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, List
 
 from starkware.python.utils import to_bytes
 from starkware.starknet.core.os.syscall_utils import initialize_contract_state
 
 from protostar.commands.test.cheatcodes.cheatcode import Cheatcode
 from protostar.commands.test.cheatcodes.prepare_cheatcode import PreparedContract
+from starkware.starknet.business_logic.execution.objects import (
+    CallInfo,
+)
 
 
 @dataclass(frozen=True)
@@ -15,6 +18,14 @@ class DeployedContract:
 
 
 class DeployCheatcode(Cheatcode):
+    def __init__(
+        self,
+        syscall_dependencies: Cheatcode.SyscallDependencies,
+        cheatable_syscall_internal_calls: List[CallInfo],
+    ):
+        super().__init__(syscall_dependencies)
+        self.internal_calls = cheatable_syscall_internal_calls
+
     @property
     def name(self) -> str:
         return "deploy"

--- a/protostar/commands/test/cheatcodes/deploy_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/deploy_cheatcode.py
@@ -22,6 +22,7 @@ class DeployCheatcode(Cheatcode):
         cheatable_syscall_internal_calls: List[CallInfo],
     ):
         super().__init__(syscall_dependencies)
+        # fixes https://github.com/software-mansion/protostar/issues/398
         self.internal_calls = cheatable_syscall_internal_calls
 
     @property


### PR DESCRIPTION
This problem was caused by using multiple syscall handlers (each cheatcode inherit from `SyscallHandler`), what eventually broke Starknet's code.

- [x] ~add test~ It's hard to isolate the problem. I'd have to analyze starknet internals even deeper, but I spent already too much time on this issue already. 