### PR TITLE
Allow disabling progress bar

### DIFF
--- a/protostar/commands/test/test_command.py
+++ b/protostar/commands/test/test_command.py
@@ -102,6 +102,7 @@ class TestCommand(Command):
         summary.assert_all_passed()
         return summary
 
+    # pylint: disable=too-many-arguments
     async def test(
         self,
         targets: List[str],

--- a/protostar/commands/test/test_command.py
+++ b/protostar/commands/test/test_command.py
@@ -83,6 +83,11 @@ class TestCommand(Command):
                 ),
                 type="bool",
             ),
+            Command.Argument(
+                name="no-progress-bar",
+                type="bool",
+                description="Disable progress bar.",
+            ),
         ]
 
     async def run(self, args) -> TestingSummary:
@@ -92,6 +97,7 @@ class TestCommand(Command):
             cairo_path=args.cairo_path,
             is_account_contract=args.account_contract,
             disable_hint_validation=args.disable_hint_validation,
+            no_progress_bar=args.no_progress_bar,
         )
         summary.assert_all_passed()
         return summary
@@ -103,6 +109,7 @@ class TestCommand(Command):
         cairo_path: Optional[List[Path]] = None,
         is_account_contract=False,
         disable_hint_validation=False,
+        no_progress_bar=False,
     ) -> TestingSummary:
         logger = getLogger()
 
@@ -126,7 +133,9 @@ class TestCommand(Command):
         )
 
         if test_collector_result.test_cases_count > 0:
-            live_logger = TestingLiveLogger(logger, testing_summary)
+            live_logger = TestingLiveLogger(
+                logger, testing_summary, no_progress_bar=no_progress_bar
+            )
             TestScheduler(live_logger, worker=TestRunner.worker).run(
                 include_paths=include_paths,
                 test_collector_result=test_collector_result,

--- a/protostar/commands/test/testing_live_logger.py
+++ b/protostar/commands/test/testing_live_logger.py
@@ -13,8 +13,11 @@ if TYPE_CHECKING:
 
 
 class TestingLiveLogger:
-    def __init__(self, logger: Logger, testing_summary: TestingSummary) -> None:
+    def __init__(
+        self, logger: Logger, testing_summary: TestingSummary, no_progress_bar: bool
+    ) -> None:
         self._logger = logger
+        self._no_progress_bar = no_progress_bar
         self.testing_summary = testing_summary
 
     def log(
@@ -29,6 +32,7 @@ class TestingLiveLogger:
                 bar_format="{l_bar}{bar}[{n_fmt}/{total_fmt}]",
                 dynamic_ncols=True,
                 leave=False,
+                disable=self._no_progress_bar,
             ) as progress_bar:
                 tests_left_n = test_collector_result.test_cases_count
                 progress_bar.update()
@@ -43,6 +47,7 @@ class TestingLiveLogger:
                             > 0
                             else "GREEN"
                         )
+
                         progress_bar.write(str(test_case_result))
 
                         if isinstance(test_case_result, BrokenTestSuite):

--- a/protostar/protostar_cli.py
+++ b/protostar/protostar_cli.py
@@ -5,24 +5,35 @@ from pathlib import Path
 from typing import Any
 
 from protostar.cli import CLIApp, Command
-from protostar.commands import (BuildCommand, DeployCommand, InitCommand,
-                                InstallCommand, RemoveCommand, TestCommand,
-                                UpdateCommand, UpgradeCommand)
+from protostar.commands import (
+    BuildCommand,
+    DeployCommand,
+    InitCommand,
+    InstallCommand,
+    RemoveCommand,
+    TestCommand,
+    UpdateCommand,
+    UpgradeCommand,
+)
 from protostar.commands.build import ProjectCompiler
-from protostar.commands.init.project_creator import (AdaptedProjectCreator,
-                                                     NewProjectCreator)
-from protostar.protostar_exception import (ProtostarException,
-                                           ProtostarExceptionSilent)
-from protostar.protostar_toml.io.protostar_toml_reader import \
-    ProtostarTOMLReader
-from protostar.protostar_toml.io.protostar_toml_writer import \
-    ProtostarTOMLWriter
-from protostar.protostar_toml.protostar_contracts_section import \
-    ProtostarContractsSection
-from protostar.protostar_toml.protostar_project_section import \
-    ProtostarProjectSection
-from protostar.utils import (Project, ProtostarDirectory, StandardLogFormatter,
-                             VersionManager, log_color_provider)
+from protostar.commands.init.project_creator import (
+    AdaptedProjectCreator,
+    NewProjectCreator,
+)
+from protostar.protostar_exception import ProtostarException, ProtostarExceptionSilent
+from protostar.protostar_toml.io.protostar_toml_reader import ProtostarTOMLReader
+from protostar.protostar_toml.io.protostar_toml_writer import ProtostarTOMLWriter
+from protostar.protostar_toml.protostar_contracts_section import (
+    ProtostarContractsSection,
+)
+from protostar.protostar_toml.protostar_project_section import ProtostarProjectSection
+from protostar.utils import (
+    Project,
+    ProtostarDirectory,
+    StandardLogFormatter,
+    VersionManager,
+    log_color_provider,
+)
 from protostar.utils.input_requester import InputRequester
 
 PROFILE_ARG = Command.Argument(

--- a/protostar/protostar_cli.py
+++ b/protostar/protostar_cli.py
@@ -5,35 +5,24 @@ from pathlib import Path
 from typing import Any
 
 from protostar.cli import CLIApp, Command
-from protostar.commands import (
-    BuildCommand,
-    DeployCommand,
-    InitCommand,
-    InstallCommand,
-    RemoveCommand,
-    TestCommand,
-    UpdateCommand,
-    UpgradeCommand,
-)
+from protostar.commands import (BuildCommand, DeployCommand, InitCommand,
+                                InstallCommand, RemoveCommand, TestCommand,
+                                UpdateCommand, UpgradeCommand)
 from protostar.commands.build import ProjectCompiler
-from protostar.commands.init.project_creator import (
-    AdaptedProjectCreator,
-    NewProjectCreator,
-)
-from protostar.protostar_exception import ProtostarException, ProtostarExceptionSilent
-from protostar.protostar_toml.io.protostar_toml_reader import ProtostarTOMLReader
-from protostar.protostar_toml.io.protostar_toml_writer import ProtostarTOMLWriter
-from protostar.protostar_toml.protostar_contracts_section import (
-    ProtostarContractsSection,
-)
-from protostar.protostar_toml.protostar_project_section import ProtostarProjectSection
-from protostar.utils import (
-    Project,
-    ProtostarDirectory,
-    StandardLogFormatter,
-    VersionManager,
-    log_color_provider,
-)
+from protostar.commands.init.project_creator import (AdaptedProjectCreator,
+                                                     NewProjectCreator)
+from protostar.protostar_exception import (ProtostarException,
+                                           ProtostarExceptionSilent)
+from protostar.protostar_toml.io.protostar_toml_reader import \
+    ProtostarTOMLReader
+from protostar.protostar_toml.io.protostar_toml_writer import \
+    ProtostarTOMLWriter
+from protostar.protostar_toml.protostar_contracts_section import \
+    ProtostarContractsSection
+from protostar.protostar_toml.protostar_project_section import \
+    ProtostarProjectSection
+from protostar.utils import (Project, ProtostarDirectory, StandardLogFormatter,
+                             VersionManager, log_color_provider)
 from protostar.utils.input_requester import InputRequester
 
 PROFILE_ARG = Command.Argument(

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -116,6 +116,8 @@ Disable hint validation in contracts declared by the `declare` cheatcode or depl
 #### `-i` `--ignore STRING[]`
 A glob or globs to a directory or a test suite, which should be ignored.
 
+#### `--no-progress-bar`
+Disable progress bar.
 ### `update`
 ```shell
 $ protostar update cairo-contracts


### PR DESCRIPTION
I didn't use `TERM` env variable because mapping `TERM` value to the useful information is not trivial. I'd probably need to use `terminfo` database and there are more important tasks to do.

![Screenshot 2022-07-07 at 15 44 14](https://user-images.githubusercontent.com/9629577/177788659-5a3670df-1cc9-4584-a356-20e2cc2f56f6.png)


