### PR TITLE
Remove test context type restriction

### DIFF
--- a/protostar/commands/test/test_context.py
+++ b/protostar/commands/test/test_context.py
@@ -6,17 +6,7 @@ from protostar.commands.test.test_environment_exceptions import SimpleReportedEx
 
 
 class TestContext(SimpleNamespace):
-    SUPPORTED_TYPES = (int, str, bool)
-
     def __setattr__(self, __name: str, __value: Any) -> None:
-        if not isinstance(__value, TestContext.SUPPORTED_TYPES):
-            raise SimpleReportedException(
-                (
-                    f"(context.{__name}) Tried to store an unsupported type: '{type(__value).__name__}'\n"
-                    f"Supported types: {[t.__name__ for t in TestContext.SUPPORTED_TYPES]}"
-                )
-            )
-
         if __name in vars(self):
             raise SimpleReportedException(
                 (

--- a/protostar/commands/test/test_context_test.py
+++ b/protostar/commands/test/test_context_test.py
@@ -4,31 +4,6 @@ from protostar.commands.test.test_context import TestContext
 from protostar.commands.test.test_environment_exceptions import ReportedException
 
 
-def test_context_supports_integers():
-    context = TestContext()
-
-    context.number = 42
-
-
-def test_context_supports_strings():
-    context = TestContext()
-
-    context.string = ""
-
-
-def test_context_supports_bools():
-    context = TestContext()
-
-    context.bool = False
-
-
-def test_not_supporting_dicts():
-    context = TestContext()
-
-    with pytest.raises(ReportedException):
-        context.number = {}
-
-
 def test_immutability():
     context = TestContext()
 

--- a/tests/integration/cheatcodes/deploy_contract/deploy_contract_test.cairo
+++ b/tests/integration/cheatcodes/deploy_contract/deploy_contract_test.cairo
@@ -36,6 +36,13 @@ namespace BasicWithConstructor:
 end
 
 @external
+func __setup__():
+    %{ context.basic_contract = deploy_contract("./tests/integration/cheatcodes/deploy_contract/basic_contract.cairo") %}
+
+    return ()
+end
+
+@external
 func test_deploy_contract{syscall_ptr : felt*, range_check_ptr}():
     alloc_locals
 
@@ -58,7 +65,7 @@ func test_deploy_contract_simplified{syscall_ptr : felt*, range_check_ptr}():
     alloc_locals
 
     local contract_address : felt
-    %{ ids.contract_address = deploy_contract("./tests/integration/cheatcodes/deploy_contract/basic_contract.cairo").contract_address %}
+    %{ ids.contract_address = context.basic_contract.contract_address %}
 
     BasicContract.increase_balance(contract_address, 5)
     let (res) = BasicContract.get_balance(contract_address)
@@ -146,7 +153,7 @@ end
 func test_syscall_after_deploy{syscall_ptr : felt*, range_check_ptr}():
     alloc_locals
     local contract_address : felt
-    %{ ids.contract_address = deploy_contract("./tests/integration/cheatcodes/deploy_contract/basic_contract.cairo").contract_address %}
+    %{ ids.contract_address = context.basic_contract.contract_address %}
 
     BasicWithConstructor.increase_balance(contract_address, 1)
     let (res) = get_contract_address()

--- a/tests/integration/testing_hooks/invalid_setup_test.cairo
+++ b/tests/integration/testing_hooks/invalid_setup_test.cairo
@@ -1,10 +1,6 @@
 %lang starknet
 
-@external
-func __setup__():
-    %{ context.foo = {} %}
-    return ()
-end
+FOOBAR
 
 @external
 func test_should_not_be_executed():

--- a/website/docs/tutorials/guides/testing.md
+++ b/website/docs/tutorials/guides/testing.md
@@ -212,9 +212,7 @@ func test_something():
     return ()
 end
 ```
-:::warning
-Hint local `context` can only store strings, integers and booleans.
-:::
+
 
 :::info
 Protostar executes `__setup__` only once per a [test suite](https://en.wikipedia.org/wiki/Test_suite). Then, for each test case Protostar copies the StarkNet state and `context` object.


### PR DESCRIPTION
Previously, `DeployedContract` stored in the `TestContext` froze Protostar, hence the restriction was added. Currently, `DeployedContract` doesn't store a reference to starknet and it can be stored in the context.