### PR TITLE
Fix data transformer in expect events

### DIFF
--- a/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 from typing_extensions import NotRequired, TypedDict
 
 from protostar.commands.test.expected_event import ExpectedEvent
-from protostar.starknet.cheatcode import Cheatcode
 from protostar.commands.test.test_environment_exceptions import (
     ExpectedEventMissingException,
 )
+from protostar.starknet.cheatcode import Cheatcode
 from protostar.utils.data_transformer_facade import DataTransformerFacade
 from protostar.utils.hook import Hook
 
@@ -107,11 +107,14 @@ class ExpectEventsCheatcode(Cheatcode):
             if "data" in raw_expected_event:
                 raw_data = raw_expected_event["data"]
                 if isinstance(raw_data, collections.Mapping):
+                    event_name_to_contract_abi_map = (
+                        self.starknet.cheatable_state.cheatable_carried_state.event_name_to_contract_abi_map
+                    )
                     assert (
-                        name in self.state.event_name_to_contract_abi_map
+                        name in event_name_to_contract_abi_map
                     ), "Couldn't map event name to the contract path with that event"
 
-                    contract_abi = self.state.event_name_to_contract_abi_map[name]
+                    contract_abi = event_name_to_contract_abi_map[name]
                     data = self.data_transformer.build_from_python_events_transformer(
                         contract_abi, name
                     )(raw_data)

--- a/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
@@ -112,7 +112,7 @@ class ExpectEventsCheatcode(Cheatcode):
                     )
                     assert (
                         name in event_name_to_contract_abi_map
-                    ), "Couldn't map event name to contract abi"
+                    ), "Couldn't map event name to contract ABI."
 
                     contract_abi = event_name_to_contract_abi_map[name]
                     data = self.data_transformer.build_from_python_events_transformer(

--- a/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
@@ -112,7 +112,7 @@ class ExpectEventsCheatcode(Cheatcode):
                     )
                     assert (
                         name in event_name_to_contract_abi_map
-                    ), "Couldn't map event name to the contract path with that event"
+                    ), "Couldn't map event name to contract abi"
 
                     contract_abi = event_name_to_contract_abi_map[name]
                     data = self.data_transformer.build_from_python_events_transformer(

--- a/protostar/commands/test/cheatcodes/mock_call_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/mock_call_cheatcode.py
@@ -15,11 +15,9 @@ class MockCallCheatcode(Cheatcode):
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
         data_transformer: DataTransformerFacade,
-        cheatable_carried_state: CheatableCarriedState,
     ):
         super().__init__(syscall_dependencies)
         self._data_transformer = data_transformer
-        self._cheatable_carried_state = cheatable_carried_state
 
     @property
     def name(self) -> str:
@@ -98,21 +96,9 @@ class MockCallCheatcode(Cheatcode):
         self, contract_address: AddressType
     ) -> Optional[AbiType]:
 
-        if (
-            contract_address
-            in self._cheatable_carried_state.contract_address_to_class_hash_map
-        ):
-            class_hash = (
-                self._cheatable_carried_state.contract_address_to_class_hash_map[
-                    contract_address
-                ]
-            )
-            if (
-                class_hash
-                in self._cheatable_carried_state.class_hash_to_contract_abi_map
-            ):
-                return self._cheatable_carried_state.class_hash_to_contract_abi_map[
-                    class_hash
-                ]
+        if contract_address in self.state.contract_address_to_class_hash_map:
+            class_hash = self.state.contract_address_to_class_hash_map[contract_address]
+            if class_hash in self.state.class_hash_to_contract_abi_map:
+                return self.state.class_hash_to_contract_abi_map[class_hash]
 
         return None

--- a/protostar/commands/test/cheatcodes/mock_call_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/mock_call_cheatcode.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from starkware.starknet.public.abi import AbiType, get_selector_from_name
 
 from protostar.commands.test.test_environment_exceptions import CheatcodeException
-from protostar.starknet.cheatable_state import CheatableCarriedState
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.starknet.types import AddressType
 from protostar.utils.data_transformer_facade import DataTransformerFacade

--- a/protostar/commands/test/environments/setup_execution_environment.py
+++ b/protostar/commands/test/environments/setup_execution_environment.py
@@ -65,7 +65,6 @@ class SetupCheatcodeFactory(CheatcodeFactory):
             MockCallCheatcode(
                 syscall_dependencies,
                 data_transformer,
-                cheatable_carried_state=self._state.starknet.cheatable_state.cheatable_carried_state,
             ),
             WarpCheatcode(syscall_dependencies),
             RollCheatcode(syscall_dependencies),

--- a/protostar/commands/test/environments/setup_execution_environment.py
+++ b/protostar/commands/test/environments/setup_execution_environment.py
@@ -62,7 +62,11 @@ class SetupCheatcodeFactory(CheatcodeFactory):
                 prepare_cheatcode,
                 deploy_cheatcode,
             ),
-            MockCallCheatcode(syscall_dependencies, data_transformer),
+            MockCallCheatcode(
+                syscall_dependencies,
+                data_transformer,
+                cheatable_carried_state=self._state.starknet.cheatable_state.cheatable_carried_state,
+            ),
             WarpCheatcode(syscall_dependencies),
             RollCheatcode(syscall_dependencies),
             StartPrankCheatcode(syscall_dependencies),

--- a/protostar/starknet/cheatable_state.py
+++ b/protostar/starknet/cheatable_state.py
@@ -21,14 +21,8 @@ from starkware.starknet.testing.state import StarknetState
 from starkware.storage.dict_storage import DictStorage
 from starkware.storage.storage import FactFetchingContext
 
-from protostar.starknet.cheatable_execute_entry_point import (
-    CheatableExecuteEntryPoint,
-)
-from protostar.starknet.types import (
-    AddressType,
-    ClassHashType,
-    SelectorType,
-)
+from protostar.starknet.cheatable_execute_entry_point import CheatableExecuteEntryPoint
+from protostar.starknet.types import AddressType, ClassHashType, SelectorType
 
 CastableToAddress = Union[str, int]
 CastableToAddressSalt = Union[str, int]

--- a/tests/integration/cheatcodes/expect_events/expect_events_test.cairo
+++ b/tests/integration/cheatcodes/expect_events/expect_events_test.cairo
@@ -18,6 +18,13 @@ namespace BasicContract:
     func increase_balance():
     end
 end
+
+@external
+func __setup__():
+    %{ context.contract_address = deploy_contract("./tests/integration/cheatcodes/expect_events/basic_contract.cairo").contract_address %}
+    return ()
+end
+
 # ----------------------------------------------------------
 
 @external
@@ -129,6 +136,19 @@ func test_data_transformation{syscall_ptr : felt*, range_check_ptr}():
     local contract_address : felt
     %{
         ids.contract_address = deploy_contract("./tests/integration/cheatcodes/expect_events/basic_contract.cairo").contract_address
+        expect_events({"name": "balance_increased", "data": {"current_balance" : 37, "amount" : 21}})
+    %}
+    BasicContract.increase_balance(contract_address=contract_address)
+
+    return ()
+end
+
+@external
+func test_data_transformation_in_contract_deployed_in_setup{syscall_ptr : felt*, range_check_ptr}():
+    alloc_locals
+    local contract_address : felt
+    %{
+        ids.contract_address = context.contract_address
         expect_events({"name": "balance_increased", "data": {"current_balance" : 37, "amount" : 21}})
     %}
     BasicContract.increase_balance(contract_address=contract_address)

--- a/tests/integration/cheatcodes/expect_events/expect_events_test.py
+++ b/tests/integration/cheatcodes/expect_events/expect_events_test.py
@@ -32,6 +32,7 @@ async def test_expect_events(mocker):
             "test_expect_events_in_declared_order",
             "test_allow_checking_for_events_in_any_order",
             "test_data_transformation",
+            "test_data_transformation_in_contract_deployed_in_setup",
         ],
         expected_failed_test_cases_names=[
             "test_fail_on_data_mismatch",

--- a/tests/integration/cheatcodes/mock_call/mock_call_test.cairo
+++ b/tests/integration/cheatcodes/mock_call/mock_call_test.cairo
@@ -21,6 +21,12 @@ namespace Mocked:
 end
 
 @external
+func __setup__():
+    %{ context.to_mock_address = deploy_contract("./tests/integration/cheatcodes/mock_call/mocked.cairo").contract_address %}
+    return ()
+end
+
+@external
 func test_remote_mock{syscall_ptr : felt*, range_check_ptr}():
     alloc_locals
 
@@ -138,6 +144,20 @@ func test_data_transformation{syscall_ptr : felt*, range_check_ptr}():
     local to_mock_address : felt
     %{
         ids.to_mock_address = deploy_contract("./tests/integration/cheatcodes/mock_call/mocked.cairo").contract_address
+        mock_call(ids.to_mock_address, "get_number", { "val": 42 })
+    %}
+    let (val) = Mocked.get_number(to_mock_address)
+    assert val = 42
+    return ()
+end
+
+@external
+func test_data_transformation_when_contract_deployed_in_setup{syscall_ptr : felt*, range_check_ptr}(
+        ):
+    alloc_locals
+    local to_mock_address : felt
+    %{
+        ids.to_mock_address = context.to_mock_address
         mock_call(ids.to_mock_address, "get_number", { "val": 42 })
     %}
     let (val) = Mocked.get_number(to_mock_address)

--- a/tests/integration/cheatcodes/mock_call/mock_call_test.cairo
+++ b/tests/integration/cheatcodes/mock_call/mock_call_test.cairo
@@ -21,12 +21,6 @@ namespace Mocked:
 end
 
 @external
-func __setup__():
-    %{ context.to_mock_address = deploy_contract("./tests/integration/cheatcodes/mock_call/mocked.cairo").contract_address %}
-    return ()
-end
-
-@external
 func test_remote_mock{syscall_ptr : felt*, range_check_ptr}():
     alloc_locals
 
@@ -144,20 +138,6 @@ func test_data_transformation{syscall_ptr : felt*, range_check_ptr}():
     local to_mock_address : felt
     %{
         ids.to_mock_address = deploy_contract("./tests/integration/cheatcodes/mock_call/mocked.cairo").contract_address
-        mock_call(ids.to_mock_address, "get_number", { "val": 42 })
-    %}
-    let (val) = Mocked.get_number(to_mock_address)
-    assert val = 42
-    return ()
-end
-
-@external
-func test_data_transformation_when_contract_deployed_in_setup{syscall_ptr : felt*, range_check_ptr}(
-        ):
-    alloc_locals
-    local to_mock_address : felt
-    %{
-        ids.to_mock_address = context.to_mock_address
         mock_call(ids.to_mock_address, "get_number", { "val": 42 })
     %}
     let (val) = Mocked.get_number(to_mock_address)


### PR DESCRIPTION
Data transformer didn't work in `expect_events` when a contract was deployed in the __setup__ function.

This problem also exists in the `mock_call` however, this fix can't be applied to `mock_call`.