### PR TITLE
Removed --stdout-on-success flag, made printing default behaviour

### DIFF
--- a/protostar/commands/test/test_command.py
+++ b/protostar/commands/test/test_command.py
@@ -110,11 +110,6 @@ class TestCommand(Command):
                 type="bool",
                 description="Exit immediately on first broken or failed test",
             ),
-            Command.Argument(
-                name="stdout-on-success",
-                type="bool",
-                description="Also print captured standard output for passed test cases.",
-            ),
         ]
 
     async def run(self, args) -> TestingSummary:
@@ -127,7 +122,6 @@ class TestCommand(Command):
             fast_collecting=args.fast_collecting,
             safe_collecting=args.safe_collecting,
             exit_first=args.exit_first,
-            stdout_on_success=args.stdout_on_success,
         )
         summary.assert_all_passed()
         return summary
@@ -143,7 +137,6 @@ class TestCommand(Command):
         fast_collecting: bool = False,
         safe_collecting: bool = False,
         exit_first: bool = False,
-        stdout_on_success: bool = False,
     ) -> TestingSummary:
         logger = getLogger()
         include_paths = [
@@ -188,7 +181,6 @@ class TestCommand(Command):
                 testing_summary,
                 no_progress_bar=no_progress_bar,
                 exit_first=exit_first,
-                stdout_on_success=stdout_on_success,
             )
             TestScheduler(live_logger, worker=TestRunner.worker).run(
                 include_paths=include_paths,

--- a/protostar/commands/test/testing_live_logger.py
+++ b/protostar/commands/test/testing_live_logger.py
@@ -68,7 +68,9 @@ class TestingLiveLogger:
                             else "GREEN"
                         )
 
-                        progress_bar.write(test_case_result.display(include_stdout_section=True))
+                        progress_bar.write(
+                            test_case_result.display(include_stdout_section=True)
+                        )
 
                         if (
                             self.exit_first

--- a/protostar/commands/test/testing_live_logger.py
+++ b/protostar/commands/test/testing_live_logger.py
@@ -68,7 +68,7 @@ class TestingLiveLogger:
                             else "GREEN"
                         )
 
-                        progress_bar.write(test_case_result.display(True))
+                        progress_bar.write(test_case_result.display(include_stdout_section=True))
 
                         if (
                             self.exit_first

--- a/protostar/commands/test/testing_live_logger.py
+++ b/protostar/commands/test/testing_live_logger.py
@@ -6,7 +6,6 @@ from tqdm import tqdm as bar
 
 from protostar.commands.test.test_cases import (
     BrokenTestSuite,
-    FailedTestCase,
     TestCaseResult,
 )
 from protostar.commands.test.test_shared_tests_state import SharedTestsState

--- a/protostar/commands/test/testing_live_logger.py
+++ b/protostar/commands/test/testing_live_logger.py
@@ -24,13 +24,11 @@ class TestingLiveLogger:
         testing_summary: TestingSummary,
         no_progress_bar: bool,
         exit_first: bool,
-        stdout_on_success: bool,
     ) -> None:
         self._logger = logger
         self._no_progress_bar = no_progress_bar
         self.testing_summary = testing_summary
         self.exit_first = exit_first
-        self.stdout_on_success = stdout_on_success
 
     def log_testing_summary(
         self, test_collector_result: "TestCollector.Result"
@@ -71,12 +69,7 @@ class TestingLiveLogger:
                             else "GREEN"
                         )
 
-                        progress_bar.write(
-                            test_case_result.display(
-                                self.stdout_on_success
-                                or isinstance(test_case_result, FailedTestCase)
-                            )
-                        )
+                        progress_bar.write(test_case_result.display(True))
 
                         if (
                             self.exit_first

--- a/tests/e2e/test_testing.py
+++ b/tests/e2e/test_testing.py
@@ -165,18 +165,12 @@ def test_exit_first_broken(protostar, copy_fixture):
 @pytest.mark.usefixtures("init")
 def test_print_passed(protostar, copy_fixture):
     copy_fixture("test_print_passed.cairo", "./tests")
-    assert "captured stdout" in protostar(
-        ["test", "--stdout-on-success", "tests"], ignore_exit_code=True
-    )
-    assert "captured stdout" not in protostar(["test", "tests"], ignore_exit_code=True)
+    assert "captured stdout" in protostar(["test", "tests"], ignore_exit_code=True)
 
 
 @pytest.mark.usefixtures("init")
 def test_print_failed(protostar, copy_fixture):
     copy_fixture("test_print_failed.cairo", "./tests")
-    assert "captured stdout" in protostar(
-        ["test", "--stdout-on-success", "tests"], ignore_exit_code=True
-    )
     assert "captured stdout" in protostar(["test", "tests"], ignore_exit_code=True)
 
 
@@ -185,16 +179,10 @@ def test_print_both(protostar, copy_fixture):
     copy_fixture("test_print_failed.cairo", "./tests")
     copy_fixture("test_print_passed.cairo", "./tests")
 
-    result = protostar(["test", "--stdout-on-success", "tests"], ignore_exit_code=True)
+    result = protostar(["test", "tests"], ignore_exit_code=True)
 
     assert result.count("captured stdout") == 2
     assert "Hello" in result
-    assert "bee" in result
-
-    result = protostar(["test", "tests"], ignore_exit_code=True)
-
-    assert result.count("captured stdout") == 1
-    assert "Hello" not in result
     assert "bee" in result
 
 
@@ -203,16 +191,9 @@ def test_print_setup(protostar, copy_fixture):
     copy_fixture("test_print_failed.cairo", "./tests")
     copy_fixture("test_print_passed.cairo", "./tests")
 
-    result = protostar(["test", "--stdout-on-success", "tests"], ignore_exit_code=True)
-
-    assert "P_SETUP" in result
-    assert "F_SETUP" in result
-    assert "[test]:" in result
-    assert "[setup]:" in result
-
     result = protostar(["test", "tests"], ignore_exit_code=True)
 
-    assert "P_SETUP" not in result
+    assert "P_SETUP" in result
     assert "F_SETUP" in result
     assert "[test]:" in result
     assert "[setup]:" in result
@@ -222,7 +203,7 @@ def test_print_setup(protostar, copy_fixture):
 def test_print_only_setup(protostar, copy_fixture):
     copy_fixture("test_print_only_setup.cairo", "./tests")
 
-    result = protostar(["test", "--stdout-on-success", "tests"], ignore_exit_code=True)
+    result = protostar(["test", "tests"], ignore_exit_code=True)
 
     assert "O_SETUP" in result
     assert "[test]:" not in result

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -139,8 +139,6 @@ A glob or globs to a directory or a test suite, which should be ignored.
 Disable progress bar.
 #### `--safe-collecting`
 Uses cairo compiler for test collection
-#### `--stdout-on-success`
-Also print captured standard output for passed test cases.
 ### `update`
 ```shell
 $ protostar update cairo-contracts


### PR DESCRIPTION
I'd like to keep optional printing functionality within the TestCaseResult class, as it is something that may be needed later.