### PR TITLE
Refactor fix for data transformer in `expect_events`

### DIFF
--- a/protostar/commands/test/cheatcodes/declare_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/declare_cheatcode.py
@@ -5,8 +5,9 @@ from typing import Any, Callable
 
 from starkware.python.utils import from_bytes
 from starkware.starknet.business_logic.internal_transaction import InternalDeclare
+from starkware.starknet.public.abi import AbiType
 from starkware.starknet.testing.contract import DeclaredClass
-from starkware.starknet.testing.contract_utils import get_abi
+from starkware.starknet.testing.contract_utils import EventManager, get_abi
 
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.utils.starknet_compilation import StarknetCompiler
@@ -63,3 +64,13 @@ class DeclareCheatcode(Cheatcode):
             class_hash=from_bytes(class_hash),
             abi=get_abi(contract_class=contract_class),
         )
+
+    def _add_event_abi_to_state(self, abi: AbiType):
+        event_manager = EventManager(abi=abi)
+        self.state.update_event_selector_to_name_map(
+            # pylint: disable=protected-access
+            event_manager._selector_to_name
+        )
+        # pylint: disable=protected-access
+        for event_name in event_manager._selector_to_name.values():
+            self.state.event_name_to_contract_abi_map[event_name] = abi

--- a/protostar/starknet/cheatcode.py
+++ b/protostar/starknet/cheatcode.py
@@ -7,9 +7,7 @@ from starkware.starknet.business_logic.execution.objects import (
 )
 from starkware.starknet.core.os.syscall_utils import BusinessLogicSysCallHandler
 from starkware.starknet.definitions.general_config import StarknetGeneralConfig
-from starkware.starknet.public.abi import AbiType
 from starkware.starknet.storage.starknet_storage import BusinessLogicStarknetStorage
-from starkware.starknet.testing.contract_utils import EventManager
 from typing_extensions import TypedDict
 
 from protostar.starknet.hint_local import HintLocal
@@ -42,21 +40,7 @@ class Cheatcode(BusinessLogicSysCallHandler, HintLocal):
         self.state = syscall_dependencies["state"]
         self.general_config = syscall_dependencies["general_config"]
         self.execute_entry_point_cls = syscall_dependencies["execute_entry_point_cls"]
-        abi = self.state.get_abi_from_contract_address(
-            syscall_dependencies["contract_address"]
-        )
-        self._add_event_abi_to_state(abi)
 
     @abstractmethod
     def build(self) -> Callable[..., Any]:
         ...
-
-    def _add_event_abi_to_state(self, abi: AbiType):
-        event_manager = EventManager(abi=abi)
-        self.state.update_event_selector_to_name_map(
-            # pylint: disable=protected-access
-            event_manager._selector_to_name
-        )
-        # pylint: disable=protected-access
-        for event_name in event_manager._selector_to_name.values():
-            self.state.event_name_to_contract_abi_map[event_name] = abi

--- a/protostar/starknet/forkable_starknet.py
+++ b/protostar/starknet/forkable_starknet.py
@@ -65,5 +65,10 @@ class ForkableStarknet(Starknet):
             # pylint: disable=protected-access
             starknet_contract.event_manager._selector_to_name
         )
+        # pylint: disable=protected-access
+        for event_name in starknet_contract.event_manager._selector_to_name.values():
+            self.cheatable_state.cheatable_carried_state.event_name_to_contract_abi_map[
+                event_name
+            ] = starknet_contract.abi
 
         return starknet_contract

--- a/tests/integration/cheatcodes/expect_events/expect_events_test.cairo
+++ b/tests/integration/cheatcodes/expect_events/expect_events_test.cairo
@@ -155,3 +155,10 @@ func test_data_transformation_in_contract_deployed_in_setup{syscall_ptr : felt*,
 
     return ()
 end
+
+@external
+func test_data_transformations_in_unit_testing_approach{syscall_ptr : felt*, range_check_ptr}():
+    %{ expect_events({"name": "foobar", "data": {"number": 42}}) %}
+    emit_foobar(42)
+    return ()
+end

--- a/tests/integration/cheatcodes/expect_events/expect_events_test.py
+++ b/tests/integration/cheatcodes/expect_events/expect_events_test.py
@@ -37,6 +37,7 @@ async def test_expect_events(mocker):
             "test_allow_checking_for_events_in_any_order",
             "test_data_transformation",
             "test_data_transformation_in_contract_deployed_in_setup",
+            "test_data_transformations_in_unit_testing_approach",
         ],
         expected_failed_test_cases_names=[
             "test_fail_on_data_mismatch",


### PR DESCRIPTION
Adding ABI in a constructor causes issues in Migration cheatcodes.

This PR was merged too fast:
https://github.com/software-mansion/protostar/pull/496