### PR TITLE
Improve assert_cairo_test_cases diffing

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,13 +19,13 @@ class CairoTestCases:
     broken: Union[int, Set[str]]
 
     def __repr__(self) -> str:
-        passed = "[Passed]\n" + "\n".join(self.passed)
-        failed = "[Failed]\n" + "\n".join(self.failed)
+        passed = "[Passed]\n" + "\n".join(sorted(self.passed))
+        failed = "[Failed]\n" + "\n".join(sorted(self.failed))
 
         if isinstance(self.broken, int):
             broken = f"Broken count: {self.broken}"
         else:
-            broken = "[Broken]\n" + "\n".join(self.broken)
+            broken = "[Broken]\n" + "\n".join(sorted(self.broken))
 
         return "\n".join([passed, failed, broken])
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Union, Set
 
 import pytest
 from pytest_mock import MockerFixture
@@ -11,21 +12,63 @@ from protostar.commands.test.testing_summary import TestingSummary
 from tests.conftest import run_devnet
 
 
+@dataclass
+class CairoTestCases:
+    passed: Set[str]
+    failed: Set[str]
+    broken: Union[int, Set[str]]
+
+    def __repr__(self) -> str:
+        passed = "[Passed]\n" + "\n".join(self.passed)
+        failed = "[Failed]\n" + "\n".join(self.failed)
+
+        if isinstance(self.broken, int):
+            broken = f"Broken count: {self.broken}"
+        else:
+            broken = "[Broken]\n" + "\n".join(self.broken)
+
+        return "\n".join([passed, failed, broken])
+
+
 def assert_cairo_test_cases(
     testing_summary: TestingSummary,
     expected_passed_test_cases_names: List[str],
     expected_failed_test_cases_names: List[str],
+    expected_broken_test_cases_names: Optional[List[str]] = None,
 ):
-
-    passed_test_cases_names = [
+    passed_test_cases_names = set(
         passed_test_case.test_case_name for passed_test_case in testing_summary.passed
-    ]
-    failed_test_cases_names = [
+    )
+    failed_test_cases_names = set(
         failed_test_case.test_case_name for failed_test_case in testing_summary.failed
-    ]
-    assert set(expected_passed_test_cases_names) == set(passed_test_cases_names)
-    assert set(expected_failed_test_cases_names) == set(failed_test_cases_names)
-    assert len(testing_summary.broken) == 0
+    )
+
+    if expected_broken_test_cases_names is None:
+        actual_broken = len(testing_summary.broken)
+    else:
+        actual_broken = set()
+        for broken_test_case in testing_summary.broken:
+            for test_case_name in broken_test_case.test_case_names:
+                actual_broken.add(test_case_name)
+
+    actual = CairoTestCases(
+        passed=passed_test_cases_names,
+        failed=failed_test_cases_names,
+        broken=actual_broken,
+    )
+
+    if expected_broken_test_cases_names is None:
+        expected_broken = 0
+    else:
+        expected_broken = set(expected_broken_test_cases_names)
+
+    expected = CairoTestCases(
+        passed=set(expected_passed_test_cases_names),
+        failed=set(expected_failed_test_cases_names),
+        broken=expected_broken,
+    )
+
+    assert actual == expected
 
 
 @pytest.fixture(name="devnet_gateway_url", scope="module")


### PR DESCRIPTION
This little PR makes debugging integration tests much more pleasant, by doing single assert statement which checks all test case sets at once, and emitting a diff-friendly representation.

Additionally, this PR adds an ability to check broken test cases.