### PR TITLE
Avoid `hypothesis.errors.MultipleFailures` exception

### DIFF
--- a/protostar/commands/test/environments/fuzz_test_execution_environment.py
+++ b/protostar/commands/test/environments/fuzz_test_execution_environment.py
@@ -80,6 +80,7 @@ class FuzzTestExecutionEnvironment(TestExecutionEnvironment):
             database=database,
             deadline=None,
             print_blob=False,
+            report_multiple_bugs=False,
             verbosity=HYPOTHESIS_VERBOSITY,
         )
         @given(data_object=data())

--- a/tests/integration/fuzzing/fuzzing_test.py
+++ b/tests/integration/fuzzing/fuzzing_test.py
@@ -57,3 +57,25 @@ async def test_state_is_isolated(run_cairo_test_runner: RunCairoTestRunnerFixtur
         ],
         expected_failed_test_cases_names=[],
     )
+
+
+@pytest.mark.asyncio
+async def test_hypothesis_multiple_errors(
+    run_cairo_test_runner: RunCairoTestRunnerFixture,
+):
+    """
+    This test potentially raises ``hypothesis.errors.MultipleFailures``
+    when ``report_multiple_bugs`` setting is set to ``True``.
+    """
+
+    testing_summary = await run_cairo_test_runner(
+        Path(__file__).parent / "hypothesis_multiple_errors_test.cairo", seed=10
+    )
+
+    assert_cairo_test_cases(
+        testing_summary,
+        expected_passed_test_cases_names=[],
+        expected_failed_test_cases_names=[
+            "test_hypothesis_multiple_errors",
+        ],
+    )

--- a/tests/integration/fuzzing/hypothesis_multiple_errors_test.cairo
+++ b/tests/integration/fuzzing/hypothesis_multiple_errors_test.cairo
@@ -1,0 +1,17 @@
+%lang starknet
+
+from starkware.cairo.common.math import assert_nn
+
+@external
+func test_hypothesis_multiple_errors{syscall_ptr : felt*, range_check_ptr}(x : felt):
+    with_attr error_message("Must be positive."):
+        assert_nn(x)
+    end
+
+    %{ expect_revert("Cannot withdraw more than stored.") %}
+    with_attr error_message("Cannot withdraw more than stored."):
+        assert_nn(1000 - x)
+    end
+
+    return ()
+end


### PR DESCRIPTION
This PR sets `report_multiple_bugs` Hypothesis setting to `False` in order to prevent it from raising a problematic`hypothesis.errors.MultipleFailures` exception. In the future we might consider reenabling this setting again and somehow trying to infer all the failures, but as for now IMHO reporting single error is helpful enough.

fix #528