### PR TITLE
Remove fuzz simplification runs info 

### DIFF
--- a/protostar/commands/test/environments/fuzz_test_execution_environment.py
+++ b/protostar/commands/test/environments/fuzz_test_execution_environment.py
@@ -11,9 +11,12 @@ from hypothesis import Verbosity, given, seed, settings
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.reporting import with_reporter
 from hypothesis.strategies import DataObject, data
-
 from starkware.starknet.business_logic.execution.objects import CallInfo
 
+from protostar.commands.test.cheatcodes import AssumeCheatcode, RejectCheatcode
+from protostar.commands.test.cheatcodes.expect_revert_cheatcode import (
+    ExpectRevertContext,
+)
 from protostar.commands.test.cheatcodes.reflect.cairo_struct import CairoStructHintLocal
 from protostar.commands.test.environments.test_execution_environment import (
     TestCaseCheatcodeFactory,
@@ -35,16 +38,6 @@ from protostar.commands.test.testing_seed import TestingSeed
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.utils.abi import get_function_parameters
 from protostar.utils.hook import Hook
-
-from protostar.commands.test.cheatcodes.expect_revert_cheatcode import (
-    ExpectRevertContext,
-)
-
-from protostar.commands.test.cheatcodes import (
-    RejectCheatcode,
-    AssumeCheatcode,
-)
-
 
 HYPOTHESIS_VERBOSITY = Verbosity.normal
 """
@@ -155,12 +148,7 @@ class FuzzTestExecutionEnvironment(TestExecutionEnvironment):
                 await to_thread(test_thread)
         except HypothesisFailureSmugglingError as escape_err:
             if runs_counter.count > 1:
-                escape_err.error.execution_info[
-                    "fuzz_runs"
-                ] = self._fuzz_config.max_examples
-                escape_err.error.execution_info["fuzz_simplification_runs"] = (
-                    runs_counter.count - self._fuzz_config.max_examples
-                )
+                escape_err.error.execution_info["fuzz_runs"] = runs_counter.count
             escape_err.error.metadata.append(
                 FuzzInputExceptionMetadata(escape_err.inputs)
             )

--- a/protostar/commands/test/environments/fuzz_test_execution_environment.py
+++ b/protostar/commands/test/environments/fuzz_test_execution_environment.py
@@ -147,8 +147,7 @@ class FuzzTestExecutionEnvironment(TestExecutionEnvironment):
             with self.state.output_recorder.redirect("test"):
                 await to_thread(test_thread)
         except HypothesisFailureSmugglingError as escape_err:
-            if runs_counter.count > 1:
-                escape_err.error.execution_info["fuzz_runs"] = runs_counter.count
+            escape_err.error.execution_info["fuzz_runs"] = runs_counter.count
             escape_err.error.metadata.append(
                 FuzzInputExceptionMetadata(escape_err.inputs)
             )

--- a/tests/integration/fuzzing/fuzzing_test.py
+++ b/tests/integration/fuzzing/fuzzing_test.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -95,6 +94,3 @@ async def test_max_fuzz_runs_less_or_equal_than_specified(
 
     assert testing_summary.passed[0].fuzz_runs_count is not None
     assert testing_summary.passed[0].fuzz_runs_count <= fuzz_max_examples
-    failed_test_execution_info = testing_summary.failed[0].exception.execution_info
-    assert cast(int, failed_test_execution_info["fuzz_runs"]) <= fuzz_max_examples
-    assert cast(int, failed_test_execution_info["fuzz_simplification_runs"]) >= 0


### PR DESCRIPTION
This info was calculated under the assumption that `fuzz_runs` is equal to `fuzz_max_examples` which is not the case.