### PR TITLE
Remove the [BUG] prefix from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
+title: ''
 labels: 'bug'
 assignees: ''
 


### PR DESCRIPTION
Personally, I find this prefix noisy, as we already have the very shouty red `bug` label. Wdyt?