### PR TITLE
fix copy_fixture typing to accept str as arguments

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -3,7 +3,7 @@ import shutil
 from os import chdir, getcwd, mkdir, path
 from pathlib import Path
 from subprocess import PIPE, STDOUT, run
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import pexpect
 import pytest
@@ -30,7 +30,9 @@ def cairo_fixtures_dir():
 
 
 @pytest.fixture
-def copy_fixture(cairo_fixtures_dir) -> Callable[[Path, Path], None]:
+def copy_fixture(
+    cairo_fixtures_dir,
+) -> Callable[[Union[Path, str], Union[Path, str]], None]:
     return lambda file, dst: shutil.copy(cairo_fixtures_dir / file, dst)
 
 


### PR DESCRIPTION
fixes this issue:

![image](https://user-images.githubusercontent.com/3450050/184890355-0aa53afe-1951-4ed6-ab9b-f042afe73f01.png)
