### PR TITLE
Add option to specify install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,6 @@ To install the tool, run:
 curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash
 ```
 
-If you want to specify a version:
-
-```shell
-curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash -s -- -v 0.3.2
-```
-
 ---
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ To install the tool, run:
 ```shell
 curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash
 ```
+
+If you want to specify a version:
+
+```shell
+curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash -s -- -v 0.3.2
+```
+
 ---
 
 ## Development

--- a/install.sh
+++ b/install.sh
@@ -38,9 +38,9 @@ while getopts ":v:" opt; do
 done
 
 if [ -n "$VERSION" ]; then
-  DESIRED_VERSION="tag/v${VERSION}"
+  REQUESTED_REF="tag/v${VERSION}"
 else
-  DESIRED_VERSION="latest"
+  REQUESTED_REF="latest"
   VERSION="latest"
 fi
 
@@ -48,20 +48,20 @@ PROTOSTAR_REPO="https://github.com/software-mansion/protostar"
 
 echo Retrieving $VERSION version from $PROTOSTAR_REPO...
 
-DESIRED_RELEASE=$(curl -L -s -H 'Accept: application/json' "${PROTOSTAR_REPO}/releases/${DESIRED_VERSION}")
+REQUESTED_RELEASE=$(curl -L -s -H 'Accept: application/json' "${PROTOSTAR_REPO}/releases/${REQUESTED_REF}")
 
-if [ "$DESIRED_RELEASE" == "{\"error\":\"Not Found\"}" ]; then
+if [ "$REQUESTED_RELEASE" == "{\"error\":\"Not Found\"}" ]; then
   echo "Version $VERSION not found"
   exit
 fi
 
-DESIRED_VERSION=$(echo $DESIRED_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+REQUESTED_VERSION=$(echo $REQUESTED_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
-echo Using version $DESIRED_VERSION
+echo Using version $REQUESTED_VERSION
 
-DESIRED_RELEASE_URL="${PROTOSTAR_REPO}/releases/download/${DESIRED_VERSION}"
+REQUESTED_RELEASE_URL="${PROTOSTAR_REPO}/releases/download/${REQUESTED_VERSION}"
 PROTOSTAR_TARBALL_NAME="protostar-${PLATFORM}.tar.gz"
-TARBALL_DOWNLOAD_URL="${DESIRED_RELEASE_URL}/${PROTOSTAR_TARBALL_NAME}"
+TARBALL_DOWNLOAD_URL="${REQUESTED_RELEASE_URL}/${PROTOSTAR_TARBALL_NAME}"
 
 echo "Downloading protostar from ${TARBALL_DOWNLOAD_URL}"
 curl -L $TARBALL_DOWNLOAD_URL | tar -xvzC $PROTOSTAR_DIR

--- a/install.sh
+++ b/install.sh
@@ -21,18 +21,47 @@ case $PLATFORM in
     ;;
 esac
 
+while getopts ":v:" opt; do
+  case $opt in
+    v)
+      VERSION=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -n "$VERSION" ]; then
+  DESIRED_VERSION="tag/v${VERSION}"
+else
+  DESIRED_VERSION="latest"
+  VERSION="latest"
+fi
+
 PROTOSTAR_REPO="https://github.com/software-mansion/protostar"
 
-echo Retrieving the latest version from $PROTOSTAR_REPO...
+echo Retrieving $VERSION version from $PROTOSTAR_REPO...
 
-LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' "${PROTOSTAR_REPO}/releases/latest")
-LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+DESIRED_RELEASE=$(curl -L -s -H 'Accept: application/json' "${PROTOSTAR_REPO}/releases/${DESIRED_VERSION}")
 
-echo Using version $LATEST_VERSION
+if [ "$DESIRED_RELEASE" == "{\"error\":\"Not Found\"}" ]; then
+  echo "Version $VERSION not found"
+  exit
+fi
 
-LATEST_RELEASE_URL="${PROTOSTAR_REPO}/releases/download/${LATEST_VERSION}"
+DESIRED_VERSION=$(echo $DESIRED_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+
+echo Using version $DESIRED_VERSION
+
+DESIRED_RELEASE_URL="${PROTOSTAR_REPO}/releases/download/${DESIRED_VERSION}"
 PROTOSTAR_TARBALL_NAME="protostar-${PLATFORM}.tar.gz"
-TARBALL_DOWNLOAD_URL="${LATEST_RELEASE_URL}/${PROTOSTAR_TARBALL_NAME}"
+TARBALL_DOWNLOAD_URL="${DESIRED_RELEASE_URL}/${PROTOSTAR_TARBALL_NAME}"
 
 echo "Downloading protostar from ${TARBALL_DOWNLOAD_URL}"
 curl -L $TARBALL_DOWNLOAD_URL | tar -xvzC $PROTOSTAR_DIR

--- a/website/docs/tutorials/02-installation.md
+++ b/website/docs/tutorials/02-installation.md
@@ -15,6 +15,13 @@ curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/inst
 2. Restart the terminal.
 3. Run `protostar -v` to check Protostar and [cairo-lang](https://pypi.org/project/cairo-lang/) version.
 
+### Specifying version
+
+If you want to specify a version of protostar to install run the following command with the requested version:
+
+```console
+curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash -s -- -v 0.3.2
+```
 
 ## Windows
 Not supported. 


### PR DESCRIPTION
Adds option `-v` to install script, in the lack of if, it will install latest version.

On specifying a non existent version, it will fail gracefully:

```bash
$ ./install.sh -v 0.3.33
Installing protostar
Retrieving 0.3.33 version from https://github.com/software-mansion/protostar...
Version 0.3.33 not found
```

Fixes #570 #638