### PR TITLE
Add `ReportedException.get_metadata_by_type`

### DIFF
--- a/protostar/commands/test/test_case_runners/fuzz_test_case_runner.py
+++ b/protostar/commands/test/test_case_runners/fuzz_test_case_runner.py
@@ -65,9 +65,10 @@ class FuzzTestCaseRunner(TestCaseRunner[FuzzTestExecutionResult]):
     def _map_reported_exception_to_fuzz_result(
         reported_exception: ReportedException,
     ) -> Optional[FuzzResult]:
-        metadata = reported_exception.metadata
-        if len(metadata) > 0 and isinstance(metadata[0], FuzzInputExceptionMetadata):
+        fuzz_input = reported_exception.get_metadata_by_type(FuzzInputExceptionMetadata)
+        if fuzz_input:
             fuzz_runs_count = reported_exception.execution_info["fuzz_runs"]
             assert isinstance(fuzz_runs_count, int)
-            return FuzzResult(fuzz_runs_count)
+            return FuzzResult(fuzz_runs_count=fuzz_runs_count)
+
         return None

--- a/protostar/commands/test/test_environment_exceptions.py
+++ b/protostar/commands/test/test_environment_exceptions.py
@@ -28,6 +28,10 @@ TMetadata = TypeVar("TMetadata", bound=ExceptionMetadata)
 class ReportedException(BaseException):
     """
     The exception used for catching unexpected errors thrown from test cases and as a base class.
+
+    Contract:
+        It is illegal to attach many same-type instances of ExceptionMetadata to the same exception
+        object.
     """
 
     def __init__(self, *args: object) -> None:

--- a/protostar/commands/test/test_environment_exceptions.py
+++ b/protostar/commands/test/test_environment_exceptions.py
@@ -50,7 +50,6 @@ class ReportedException(BaseException):
     def get_metadata_by_type(
         self, metadata_type: Type[TMetadata]
     ) -> Optional[TMetadata]:
-        # Note: Typing this function is hard, hence omitted.
         for metadata in self.metadata:
             if isinstance(metadata, metadata_type):
                 return metadata

--- a/protostar/commands/test/test_environment_exceptions.py
+++ b/protostar/commands/test/test_environment_exceptions.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, TypeVar, Type
 
 from starkware.starknet.business_logic.execution.objects import Event
 from typing_extensions import Literal
@@ -20,6 +20,9 @@ class ExceptionMetadata(ABC):
     @abstractmethod
     def format(self) -> str:
         ...
+
+
+TMetadata = TypeVar("TMetadata", bound=ExceptionMetadata)
 
 
 class ReportedException(BaseException):
@@ -43,6 +46,16 @@ class ReportedException(BaseException):
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.__dict__ == other.__dict__
+
+    def get_metadata_by_type(
+        self, metadata_type: Type[TMetadata]
+    ) -> Optional[TMetadata]:
+        # Note: Typing this function is hard, hence omitted.
+        for metadata in self.metadata:
+            if isinstance(metadata, metadata_type):
+                return metadata
+
+        return None
 
 
 class SimpleReportedException(ReportedException):

--- a/protostar/commands/test/test_environment_exceptions_test.py
+++ b/protostar/commands/test/test_environment_exceptions_test.py
@@ -102,6 +102,24 @@ def test_matching_by_partial_error_message():
     assert not RevertableException(error_message=["f", "b"]).match(ex)
 
 
+def test_get_metadata_by_type():
+    class UnusedMockMetadata(ExceptionMetadata):
+        @property
+        def name(self) -> str:
+            return "unused"
+
+        def format(self) -> str:
+            return "unused"
+
+    ex = SimpleReportedException("foo")
+
+    metadata = MockMetadata()
+    ex.metadata.append(metadata)
+
+    assert ex.get_metadata_by_type(MockMetadata) is metadata
+    assert ex.get_metadata_by_type(UnusedMockMetadata) is None
+
+
 @pytest.mark.parametrize(
     "exception",
     [


### PR DESCRIPTION
Small change which increases code robustness in case new metadata types are added.