### PR TITLE
Fix flaky test and rename fixture

### DIFF
--- a/tests/e2e/installation_script/conftest.py
+++ b/tests/e2e/installation_script/conftest.py
@@ -95,17 +95,19 @@ class ProtostarGitHubRepository:
         return f'"tag_name":"v{version}"'
 
 
-class SimulateUnwrappingFixture(Protocol):
+class CreateFakeProtostarFixture(Protocol):
     def __call__(self, output_dir: Path) -> None:
         ...
 
 
-@pytest.fixture(name="simulate_unwrapping")
-def simulate_unwrapping_fixture(datadir: Path) -> SimulateUnwrappingFixture:
-    def simulate_unwrapping(output_dir: Path):
+@pytest.fixture(name="create_fake_protostar")
+def create_fake_protostar_fixture(
+    datadir: Path,
+) -> CreateFakeProtostarFixture:
+    def create_fake_protostar(output_dir: Path):
         copytree(src=datadir / "dist", dst=output_dir / ".protostar" / "dist")
 
-    return simulate_unwrapping
+    return create_fake_protostar
 
 
 def assert_config_file_includes_path_entry(file_path: Path, home_path: Path):

--- a/tests/e2e/installation_script/test_install_sh.py
+++ b/tests/e2e/installation_script/test_install_sh.py
@@ -4,9 +4,15 @@ from pathlib import Path
 import pytest
 
 from tests.e2e.installation_script.conftest import (
-    CreateFakeProtostarFixture, ProtostarGitHubRepository,
-    ScriptTestingHarness, Shell, SupportedKernel, SupportedShell,
-    UploadedInstallationFilename, assert_config_file_includes_path_entry)
+    CreateFakeProtostarFixture,
+    ProtostarGitHubRepository,
+    ScriptTestingHarness,
+    Shell,
+    SupportedKernel,
+    SupportedShell,
+    UploadedInstallationFilename,
+    assert_config_file_includes_path_entry,
+)
 
 
 @pytest.fixture(name="home_path")

--- a/tests/e2e/installation_script/test_install_sh.py
+++ b/tests/e2e/installation_script/test_install_sh.py
@@ -4,15 +4,9 @@ from pathlib import Path
 import pytest
 
 from tests.e2e.installation_script.conftest import (
-    ProtostarGitHubRepository,
-    ScriptTestingHarness,
-    Shell,
-    SimulateUnwrappingFixture,
-    SupportedKernel,
-    SupportedShell,
-    UploadedInstallationFilename,
-    assert_config_file_includes_path_entry,
-)
+    CreateFakeProtostarFixture, ProtostarGitHubRepository,
+    ScriptTestingHarness, Shell, SupportedKernel, SupportedShell,
+    UploadedInstallationFilename, assert_config_file_includes_path_entry)
 
 
 @pytest.fixture(name="home_path")
@@ -43,7 +37,7 @@ def latest_protostar_version_fixture() -> str:
 def test_installing_latest_version(
     home_path: Path,
     latest_protostar_version: str,
-    simulate_unwrapping: SimulateUnwrappingFixture,
+    create_fake_protostar: CreateFakeProtostarFixture,
     kernel: str,
     shell: Shell,
     uploaded_installation_filename: str,
@@ -65,10 +59,10 @@ def test_installing_latest_version(
     harness.expect_download_curl_prompt(
         uploaded_installation_filename, latest_protostar_version
     )
+    create_fake_protostar(output_dir=home_path)
     harness.send("DATA")
 
     harness.expect_tar_call(data="DATA")
-    simulate_unwrapping(output_dir=home_path)
 
     harness.expect_detected_shell(shell_name=shell.name)
     harness.expect_eof()
@@ -95,7 +89,7 @@ def test_installing_latest_version(
 )
 def test_installing_specific_version(
     home_path: Path,
-    simulate_unwrapping: SimulateUnwrappingFixture,
+    create_fake_protostar: CreateFakeProtostarFixture,
     kernel: str,
     shell: Shell,
     uploaded_installation_filename: str,
@@ -121,10 +115,10 @@ def test_installing_specific_version(
     harness.expect_download_curl_prompt(
         uploaded_installation_filename, requested_version
     )
+    create_fake_protostar(output_dir=home_path)
     harness.send("DATA")
 
     harness.expect_tar_call(data="DATA")
-    simulate_unwrapping(output_dir=home_path)
 
     harness.expect_detected_shell(shell_name=shell.name)
     harness.expect_eof()


### PR DESCRIPTION
Flaky test was caused by a race condition (`simulate_unwrapping` vs `chmod`)