### PR TITLE
Silence Pylint error

### DIFF
--- a/protostar/commands/test/cheatcodes/reflect/cairo_struct_test.py
+++ b/protostar/commands/test/cheatcodes/reflect/cairo_struct_test.py
@@ -44,10 +44,10 @@ def test_cairo_struct_equality():
 
 
 def test_cairo_struct_immutability():
-    x = CairoStruct(a=0b0110, b=0b1001)
+    x = CairoStruct(i=0b0110, j=0b1001)
 
     with pytest.raises(SimpleReportedException) as exc:
-        x.b = 0b1000101
+        x.j = 0b1000101
     assert "CairoStruct is immutable." in str(exc.value)
 
 


### PR DESCRIPTION
This PR workarounds this error which pops for me from time to time.

```
************* Module protostar.commands.test.cheatcodes.reflect.cairo_struct_test
protostar/commands/test/cheatcodes/reflect/cairo_struct_test.py:50:8: C0103: Attribute name "b" doesn't conform to snake_case naming style (invalid-name)
```

Personally I would disable this inspection.