### PR TITLE
Clean up test mode determination logic

### DIFF
--- a/protostar/commands/test/environments/test_execution_environment.py
+++ b/protostar/commands/test/environments/test_execution_environment.py
@@ -10,7 +10,6 @@ from protostar.commands.test.cheatcodes import (
 from protostar.commands.test.cheatcodes.expect_revert_cheatcode import (
     ExpectRevertContext,
 )
-from protostar.commands.test.cheatcodes.reflect.cairo_struct import CairoStructHintLocal
 from protostar.commands.test.environments.setup_execution_environment import (
     SetupCheatcodeFactory,
 )
@@ -18,7 +17,6 @@ from protostar.commands.test.starkware.execution_resources_summary import (
     ExecutionResourcesSummary,
 )
 from protostar.commands.test.starkware.test_execution_state import TestExecutionState
-from protostar.commands.test.test_context import TestContextHintLocal
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.starknet.execution_environment import ExecutionEnvironment
 from protostar.utils.abi import has_function_parameters
@@ -39,7 +37,6 @@ class TestExecutionEnvironment(ExecutionEnvironment[TestExecutionResult]):
         self._finish_hook = Hook()
 
     async def invoke(self, function_name: str) -> TestExecutionResult:
-        # TODO(mkaput): Raise broken test error if test has any arguments.
         assert not has_function_parameters(
             self.state.contract.abi, function_name
         ), f"{self.__class__.__name__} expects no function parameters."

--- a/protostar/commands/test/starkware/test_execution_state.py
+++ b/protostar/commands/test/starkware/test_execution_state.py
@@ -9,6 +9,7 @@ from protostar.commands.test.stopwatch import Stopwatch
 from protostar.commands.test.test_config import TestConfig
 from protostar.commands.test.test_context import TestContext
 from protostar.commands.test.test_output_recorder import OutputRecorder
+from protostar.commands.test.test_suite import TestCase
 from protostar.starknet.execution_state import ExecutionState
 from protostar.starknet.forkable_starknet import ForkableStarknet
 from protostar.utils.starknet_compilation import StarknetCompiler
@@ -55,3 +56,6 @@ class TestExecutionState(ExecutionState):
             output_recorder=self.output_recorder.fork(),
             stopwatch=self.stopwatch.fork(),
         )
+
+    def determine_test_mode(self, test_case: TestCase):
+        self.config.determine_mode(test_case=test_case, contract=self.contract)

--- a/protostar/commands/test/test_case_runners/test_case_runner_factory.py
+++ b/protostar/commands/test/test_case_runners/test_case_runner_factory.py
@@ -21,7 +21,11 @@ class TestCaseRunnerFactory:
         self._state = state
 
     def make(self, test_case: TestCase) -> TestCaseRunner:
-        if self._state.config.mode is TestMode.FUZZ:
+        mode = self._state.config.mode
+
+        assert mode, "Test mode should be determined at this point."
+
+        if mode is TestMode.FUZZ:
             return FuzzTestCaseRunner(
                 fuzz_test_execution_environment=FuzzTestExecutionEnvironment(
                     self._state
@@ -31,7 +35,7 @@ class TestCaseRunnerFactory:
                 stopwatch=self._state.stopwatch,
             )
 
-        if self._state.config.mode is TestMode.STANDARD:
+        if mode is TestMode.STANDARD:
             return StandardTestCaseRunner(
                 test_execution_environment=TestExecutionEnvironment(self._state),
                 test_case=test_case,
@@ -39,4 +43,4 @@ class TestCaseRunnerFactory:
                 stopwatch=self._state.stopwatch,
             )
 
-        raise NotImplementedError(f"Unreachable")
+        raise NotImplementedError("Unreachable")

--- a/protostar/commands/test/test_config.py
+++ b/protostar/commands/test/test_config.py
@@ -70,7 +70,7 @@ class TestMode(Enum):
 
     def __bool__(self) -> bool:
         """
-        Gives ``None``-like semantics to the ``UNDETERMINED`` case.
+        ``UNDETERMINED`` is treated as ``False`` in if statements.
         """
         return self is not self.UNDETERMINED
 

--- a/protostar/commands/test/test_config.py
+++ b/protostar/commands/test/test_config.py
@@ -12,7 +12,7 @@ from protostar.utils.abi import has_function_parameters
 class TestModeConversionException(ProtostarException):
     def __init__(self, from_mode: "TestMode", to_mode: "TestMode"):
         super().__init__(
-            f"Cannot convert test case from {from_mode.human_name} to {to_mode.human_name}. "
+            f"Cannot convert test case from {from_mode.pretty_name} to {to_mode.pretty_name}. "
             "Do not mix configuration cheatcodes specific to both modes in single test setup hooks."
         )
 
@@ -23,7 +23,7 @@ class TestMode(Enum):
     FUZZ = 2
 
     @property
-    def human_name(self) -> str:
+    def pretty_name(self) -> str:
         if self is self.UNDETERMINED:
             # Note: This should be an unreachable case, but because this property is used
             #   in exception constructors, a fallback value in exception message would be more

--- a/protostar/commands/test/test_config.py
+++ b/protostar/commands/test/test_config.py
@@ -4,14 +4,54 @@ from enum import Enum
 from starkware.starknet.testing.contract import StarknetContract
 from typing_extensions import Self
 
+from protostar.commands.test.test_suite import TestCase
+from protostar.protostar_exception import ProtostarException
 from protostar.utils.abi import has_function_parameters
 
 
+class TestModeConversionException(ProtostarException):
+    def __init__(self, from_mode: "TestMode", to_mode: "TestMode"):
+        super().__init__(
+            f"Cannot convert test case from {from_mode.human_name} to {to_mode.human_name}. "
+            "Do not mix configuration cheatcodes specific to both modes in single test setup hooks."
+        )
+
+
 class TestMode(Enum):
+    UNDETERMINED = 0
     STANDARD = 1
     FUZZ = 2
 
-    # TODO(mkaput): Remove this in favor of setting mode explicitly by cheatcodes in setup hooks.
+    @property
+    def human_name(self) -> str:
+        if self is self.UNDETERMINED:
+            # Note: This should be an unreachable case, but because this property is used
+            #   in exception constructors, a fallback value in exception message would be more
+            #   informational in case of bugs.
+            return "mode ?"
+
+        if self is self.STANDARD:
+            return "standard mode"
+
+        if self is self.FUZZ:
+            return "fuzzing mode"
+
+        raise NotImplementedError("Unreachable.")
+
+    def can_convert_to(self, to_mode: Self) -> bool:
+        return not self or (self, to_mode) in {
+            (self.STANDARD, self.FUZZ),
+        }
+
+    def convert_to(self, to_mode: Self) -> Self:
+        if not self.can_convert_to(to_mode):
+            raise TestModeConversionException(from_mode=self, to_mode=to_mode)
+
+        return to_mode
+
+    def determine(self, function_name: str, contract: StarknetContract) -> Self:
+        return self or self.infer_from_contract_function(function_name, contract)
+
     @classmethod
     def infer_from_contract_function(
         cls, function_name: str, contract: StarknetContract
@@ -21,9 +61,23 @@ class TestMode(Enum):
 
         return cls.STANDARD
 
+    def __bool__(self) -> bool:
+        """
+        Gives ``None``-like semantics to the ``UNDETERMINED`` case.
+        """
+        return self is not self.UNDETERMINED
+
 
 @dataclass
 class TestConfig:
-    mode: TestMode = TestMode.STANDARD
+    mode: TestMode = TestMode.UNDETERMINED
 
     fuzz_max_examples: int = 100
+
+    def convert_mode_to(self, to_mode: TestMode):
+        self.mode = self.mode.convert_to(to_mode)
+
+    def determine_mode(self, test_case: TestCase, contract: StarknetContract):
+        self.mode = self.mode.determine(
+            function_name=test_case.test_fn_name, contract=contract
+        )

--- a/protostar/commands/test/test_config.py
+++ b/protostar/commands/test/test_config.py
@@ -39,9 +39,16 @@ class TestMode(Enum):
         raise NotImplementedError("Unreachable.")
 
     def can_convert_to(self, to_mode: Self) -> bool:
-        return not self or (self, to_mode) in {
-            (self.STANDARD, self.FUZZ),
-        }
+        return (
+            self is self.UNDETERMINED
+            or self is to_mode
+            or (
+                (self, to_mode)
+                in {
+                    (self.STANDARD, self.FUZZ),
+                }
+            )
+        )
 
     def convert_to(self, to_mode: Self) -> Self:
         if not self.can_convert_to(to_mode):

--- a/protostar/commands/test/test_config_test.py
+++ b/protostar/commands/test/test_config_test.py
@@ -8,7 +8,13 @@ from protostar.commands.test.test_config import TestMode, TestModeConversionExce
     [
         (TestMode.STANDARD, TestMode.FUZZ, True),
         (TestMode.FUZZ, TestMode.STANDARD, False),
+        *[(mode, mode, True) for mode in TestMode],
         *[(TestMode.UNDETERMINED, mode, True) for mode in TestMode],
+        *[
+            (mode, TestMode.UNDETERMINED, False)
+            for mode in TestMode
+            if mode is not TestMode.UNDETERMINED
+        ],
     ],
 )
 def test_mode_conversion(from_mode: TestMode, to_mode: TestMode, expected: bool):

--- a/protostar/commands/test/test_config_test.py
+++ b/protostar/commands/test/test_config_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from protostar.commands.test.test_config import TestMode, TestModeConversionException
+
+
+@pytest.mark.parametrize(
+    "from_mode,to_mode,expected",
+    [
+        (TestMode.STANDARD, TestMode.FUZZ, True),
+        (TestMode.FUZZ, TestMode.STANDARD, False),
+        *[(TestMode.UNDETERMINED, mode, True) for mode in TestMode],
+    ],
+)
+def test_mode_conversion(from_mode: TestMode, to_mode: TestMode, expected: bool):
+    assert from_mode.can_convert_to(to_mode) == expected
+
+    if expected:
+        assert from_mode.convert_to(to_mode) == to_mode
+    else:
+        with pytest.raises(TestModeConversionException):
+            from_mode.convert_to(to_mode)

--- a/protostar/commands/test/test_runner.py
+++ b/protostar/commands/test/test_runner.py
@@ -15,7 +15,7 @@ from protostar.commands.test.test_case_runners.setup_case_runner import run_setu
 from protostar.commands.test.test_case_runners.test_case_runner_factory import (
     TestCaseRunnerFactory,
 )
-from protostar.commands.test.test_config import TestConfig, TestMode
+from protostar.commands.test.test_config import TestConfig
 from protostar.commands.test.test_environment_exceptions import ReportedException
 from protostar.commands.test.test_results import (
     BrokenTestSuiteResult,
@@ -182,10 +182,7 @@ class TestRunner:
             if isinstance(setup_case_result, FailedSetupCaseResult):
                 return setup_case_result.into_failed_test_case_result()
 
-        # TODO(mkaput): Remove this in favor of setting mode explicitly by cheatcodes in setup hooks.
-        state.config.mode = TestMode.infer_from_contract_function(
-            test_case.test_fn_name, state.contract
-        )
+        state.determine_test_mode(test_case)
 
         test_case_runner_factory = TestCaseRunnerFactory(state)
         test_case_runner = test_case_runner_factory.make(test_case)


### PR DESCRIPTION
This PR cleans up the logic for inferring test mode from test case function signature. I have decided to leave the behaviour so that we won't break existing fuzz tests in users' projects, i.e. this will still work:

```cairo
# No __setup__, no setup_foo
@external
def test_foo(a):
    ...
end
```

I am unsure about adding the `TestMode.UNDETERMINED` variant. My rationale behind this was to mark explicitly cases when inference is *needed*, instead of making a wild assumption that `TestMode.STANDARD` means this (who knows if we someday introduce a unit test specific cheatcode). Correct me if I'm wrong 😀

This is the last PR before submitting fuzzing strategies API rework. That PR will use the `convert_mode_to` method added to `TestConfig`