### PR TITLE
Simplify types around `expect_events` cheatcode

### DIFF
--- a/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
     from protostar.starknet.forkable_starknet import ForkableStarknet
 
 
-class ExpectedEventData(TypedDict):
+class RawExpectedEventData(TypedDict):
     name: str
     data: NotRequired[CairoOrPythonData]
     from_address: NotRequired[int]
 
 
-ExpectedEventName = str
+RawExpectedEventName = str
 
-ExpectedEvent = Union[ExpectedEventData, ExpectedEventName]
+RawExpectedEvent = Union[RawExpectedEventData, RawExpectedEventName]
 
 
 class ExpectEventsCheatcode(Cheatcode):
@@ -46,7 +46,10 @@ class ExpectEventsCheatcode(Cheatcode):
     def build(self) -> Callable:
         return self.expect_events
 
-    def expect_events(self, *raw_expected_events: ExpectedEvent) -> None:
+    def expect_events(
+        self,
+        *raw_expected_events: RawExpectedEvent,
+    ) -> None:
         def compare_expected_and_emitted_events():
             expected_events = list(
                 map(
@@ -75,7 +78,7 @@ class ExpectEventsCheatcode(Cheatcode):
 
     def _convert_raw_expected_event_to_expected_event(
         self,
-        raw_expected_event: ExpectedEvent,
+        raw_expected_event: RawExpectedEvent,
     ):
 
         name: str

--- a/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
     from protostar.starknet.forkable_starknet import ForkableStarknet
 
 
-class EventExpectationDict(TypedDict):
+class ExpectedEventData(TypedDict):
     name: str
     data: NotRequired[CairoOrPythonData]
     from_address: NotRequired[int]
 
 
-EventExpectationName = str
+ExpectedEventName = str
 
-EventExpectation = Union[EventExpectationDict, EventExpectationName]
+ExpectedEvent = Union[ExpectedEventData, ExpectedEventName]
 
 
 class ExpectEventsCheatcode(Cheatcode):
@@ -46,13 +46,12 @@ class ExpectEventsCheatcode(Cheatcode):
     def build(self) -> Callable:
         return self.expect_events
 
-    def expect_events(self, *expectations: EventExpectation) -> None:
+    def expect_events(self, *raw_expected_events: ExpectedEvent) -> None:
         def compare_expected_and_emitted_events():
-
             expected_events = list(
                 map(
                     self._convert_raw_expected_event_to_expected_event,
-                    expectations,
+                    raw_expected_events,
                 )
             )
 
@@ -76,7 +75,7 @@ class ExpectEventsCheatcode(Cheatcode):
 
     def _convert_raw_expected_event_to_expected_event(
         self,
-        raw_expected_event: EventExpectation,
+        raw_expected_event: ExpectedEvent,
     ):
 
         name: str

--- a/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
+++ b/protostar/commands/test/cheatcodes/expect_events_cheatcode.py
@@ -1,4 +1,3 @@
-import collections
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 from typing_extensions import NotRequired, TypedDict

--- a/protostar/commands/test/expected_event.py
+++ b/protostar/commands/test/expected_event.py
@@ -7,8 +7,6 @@ from starkware.starknet.business_logic.execution.objects import Event
 from starkware.starknet.public.abi import get_selector_from_name
 from typing_extensions import Literal
 
-from protostar.commands.test.test_suite import TestSuite
-
 
 @dataclass
 class ExpectedEvent:
@@ -68,6 +66,3 @@ class ExpectedEvent:
                 or self.from_address == state_event.from_address
             )
         )
-
-
-TestSubject = TestSuite

--- a/website/docs/tutorials/07-testing/02-cheatcodes/expect-events.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/expect-events.md
@@ -1,4 +1,3 @@
-
 # `expect_events`
 ```python
 class EventExpectationDict(TypedDict):

--- a/website/docs/tutorials/07-testing/02-cheatcodes/expect-events.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/expect-events.md
@@ -1,28 +1,16 @@
+
 # `expect_events`
 ```python
- def expect_events(
-            *raw_expected_events: Union[
-                str, # Protostar interprets string as an event's name 
-                TypedDict("ExpectedEvent", {
-                    "name": str,
-                    "data": NotRequired[Union[
-                      List[int],
-                      Dict[
-                        # e.g.
-                        # {"current_balance" : 37, "amount" : 21}
-                        # 
-                        # for the following event signature:
-                        # @event
-                        # func balance_increased(current_balance : felt, amount : felt):
-                        # end
-                        DataTransformer.ArgumentName,
-                        DataTransformer.SupportedType,
-                      ]
-                    ]],
-                    "from_address": NotRequired[int]
-                },
-            )],
-        ) -> None: ...
+class EventExpectationDict(TypedDict):
+    name: str
+    data: NotRequired[list[int] | dict[str, Any]]
+    from_address: NotRequired[int]
+
+EventExpectationName = str
+
+EventExpectation = EventExpectationDict | EventExpectationName
+
+def expect_events(*expectations: EventExpectation) -> None: ...
 ```
 Compares expected events with events in the StarkNet state. You can use this cheatcode to test whether a contract emits specified events. Protostar compares events after a test case is completed. Therefore, you can use this cheatcode in any place within a test case.
 

--- a/website/docs/tutorials/07-testing/02-cheatcodes/expect-events.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/expect-events.md
@@ -1,15 +1,15 @@
 # `expect_events`
 ```python
-class EventExpectationDict(TypedDict):
+class ExpectedEventData(TypedDict):
     name: str
-    data: NotRequired[list[int] | dict[str, Any]]
+    data: NotRequired[list[int] | dict[str, Any] | None]
     from_address: NotRequired[int]
 
-EventExpectationName = str
+ExpectedEventName = str
 
-EventExpectation = EventExpectationDict | EventExpectationName
+ExpectedEvent = ExpectedEventData | ExpectedEventName
 
-def expect_events(*expectations: EventExpectation) -> None: ...
+def expect_events(*expected_events: ExpectedEvent) -> None: ...
 ```
 Compares expected events with events in the StarkNet state. You can use this cheatcode to test whether a contract emits specified events. Protostar compares events after a test case is completed. Therefore, you can use this cheatcode in any place within a test case.
 


### PR DESCRIPTION
Just found an opportunity here to clean up things.