### PR TITLE
Improve crash reporting in E2E tests and fix failing ones

### DIFF
--- a/binary_entrypoint.py
+++ b/binary_entrypoint.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import sys
 from itertools import cycle
@@ -13,6 +14,8 @@ SCRIPT_ROOT = Path(__file__).parent
 
 
 def init():
+    multiprocessing.freeze_support()
+
     start_time = perf_counter()
     fix_ssl_certificate_errors_on_macos()
     main = import_protostar_main()

--- a/tests/e2e/test_building.py
+++ b/tests/e2e/test_building.py
@@ -138,16 +138,24 @@ def test_disable_hint_validation(protostar):
 @pytest.mark.usefixtures("init")
 def test_building_account_contract(protostar):
     Path("./src/main.cairo").write_text(
-        dedent(
-            """
-            %lang starknet
-            
-            @external
-            func __execute__() {
-                return ();
-            }
-            """
-        )
+        """\
+%lang starknet
+
+@external
+func __validate__() {
+    return ();
+}
+
+@external
+func __validate_declare__(class_hash: felt) {
+    return ();
+}
+
+@external
+func __execute__() {
+    return ();
+}
+"""
     )
 
     protostar(["build"])

--- a/tests/e2e/test_building.py
+++ b/tests/e2e/test_building.py
@@ -1,5 +1,5 @@
 from os import listdir
-from subprocess import CalledProcessError
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -16,15 +16,17 @@ def test_default_build(protostar):
 
 @pytest.mark.usefixtures("init")
 def test_non_zero_exit_code_if_fails(protostar):
-    with open("./src/main.cairo", mode="w", encoding="utf-8") as my_contract:
-        my_contract.write(
-            """%lang starknet
-@view
-func broken():
-"""
+    Path("./src/main.cairo").write_text(
+        dedent(
+            """
+            %lang starknet
+            @view
+            func broken() {
+            """
         )
-    with pytest.raises(CalledProcessError):
-        protostar(["build"])
+    )
+
+    protostar(["build"], expect_exit_code=1)
 
 
 @pytest.mark.usefixtures("init")
@@ -86,8 +88,7 @@ def test_cairo_path_loaded_from_command_shared_section_in_config_file(
 def test_cairo_path_loaded_from_profile_section(protostar, my_private_libs_setup):
     (my_private_libs_dir,) = my_private_libs_setup
 
-    with pytest.raises(CalledProcessError):
-        protostar(["build"])
+    protostar(["build"], expect_exit_code=1)
 
     with open("./protostar.toml", "a", encoding="utf-8") as protostar_toml:
         protostar_toml.write(
@@ -107,27 +108,25 @@ def test_cairo_path_loaded_from_profile_section(protostar, my_private_libs_setup
 
 @pytest.mark.usefixtures("init")
 def test_disable_hint_validation(protostar):
-
-    with open("./src/main.cairo", mode="w", encoding="utf-8") as my_contract:
-        my_contract.write(
-            "\n".join(
-                [
-                    "%lang starknet",
-                    "",
-                    "@view",
-                    "func use_hint():",
-                    "    tempvar x",
-                    "    %{",
-                    "        from foo import bar",
-                    "        ids.x = 42",
-                    "    %}",
-                    "    assert x = 42",
-                    "",
-                    "    return ()",
-                    "end",
-                ]
-            )
+    Path("./src/main.cairo").write_text(
+        dedent(
+            """
+            %lang starknet
+            
+            @view
+            func use_hint() {
+                tempvar x;
+                %{
+                    from foo import bar
+                    ids.x = 42
+                %}
+                assert x = 42;
+            
+                return ();
+            }
+            """
         )
+    )
 
     result = protostar(["build"], ignore_exit_code=True)
     assert "Hint is not whitelisted." in result
@@ -138,20 +137,18 @@ def test_disable_hint_validation(protostar):
 
 @pytest.mark.usefixtures("init")
 def test_building_account_contract(protostar):
-
-    with open("./src/main.cairo", mode="w", encoding="utf-8") as my_contract:
-        my_contract.write(
-            "\n".join(
-                [
-                    "%lang starknet",
-                    "",
-                    "@external",
-                    "func __execute__():",
-                    "    return ()",
-                    "end",
-                ]
-            )
+    Path("./src/main.cairo").write_text(
+        dedent(
+            """
+            %lang starknet
+            
+            @external
+            func __execute__() {
+                return ();
+            }
+            """
         )
+    )
 
     protostar(["build"])
 

--- a/tests/e2e/test_misc_commands.py
+++ b/tests/e2e/test_misc_commands.py
@@ -1,5 +1,4 @@
 # pylint: disable=redefined-outer-name
-import subprocess
 from os import listdir
 from pathlib import Path
 
@@ -83,10 +82,8 @@ def test_protostar_version_in_config_file(mocker, protostar_bin: Path):
 @pytest.mark.parametrize("latest_supported_protostar_toml_version", ["0.2.9"])
 @pytest.mark.parametrize("command", ["build", "install", "test"])
 def test_protostar_asserts_version_compatibility(protostar, command):
-    with pytest.raises(subprocess.CalledProcessError) as error:
-        protostar([command])
-
-    assert "is not compatible with provided protostar.toml" in str(error.value.output)
+    output = protostar([command], expect_exit_code=1)
+    assert "is not compatible with provided protostar.toml" in str(output)
 
 
 @pytest.mark.usefixtures("init")

--- a/tests/e2e/test_testing.py
+++ b/tests/e2e/test_testing.py
@@ -1,6 +1,5 @@
 import shutil
 from pathlib import Path
-from subprocess import CalledProcessError
 
 import pytest
 

--- a/tests/e2e/test_testing.py
+++ b/tests/e2e/test_testing.py
@@ -84,8 +84,7 @@ def test_expect_revert(protostar_repo_root: Path, protostar):
 def test_loading_cairo_path_from_config_file(protostar, my_private_libs_setup):
     (my_private_libs_dir,) = my_private_libs_setup
 
-    with pytest.raises(CalledProcessError):
-        protostar(["test", "tests"])
+    protostar(["test", "tests"], expect_exit_code=1)
 
     with open("./protostar.toml", "a", encoding="utf-8") as protostar_toml:
         protostar_toml.write(
@@ -103,8 +102,7 @@ cairo_path = ["{str(my_private_libs_dir)}"]
 @pytest.mark.usefixtures("init")
 def test_exit_code_if_any_test_failed(protostar, copy_fixture):
     copy_fixture("test_failed.cairo", "./tests")
-    with pytest.raises(CalledProcessError):
-        protostar(["test", "tests"])
+    protostar(["test", "tests"], expect_exit_code=1)
 
 
 @pytest.mark.usefixtures("init")


### PR DESCRIPTION
The only failing tests left are the devnet-dependent ones.

fixes #798