### PR TITLE
Redesigning `protostar.toml` 6 — Version checker

### DIFF
--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, Union
 
 from protostar.protostar_exception import ProtostarException
-from protostar.utils.protostar_directory import VersionType
+from protostar.self import DeclaredProtostarVersionProviderProtocol, ProtostarVersion
 
 PrimitiveTypesSupportedByConfigurationFile = Union[str, int, bool]
 
@@ -43,9 +43,11 @@ class ConfigurationFileContentConfigurator(Generic[ConfigurationFileModelT]):
         ...
 
 
-class ConfigurationFile(Generic[ConfigurationFileModelT]):
+class ConfigurationFile(
+    DeclaredProtostarVersionProviderProtocol, Generic[ConfigurationFileModelT]
+):
     @abstractmethod
-    def get_min_protostar_version(self) -> Optional[VersionType]:
+    def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:
         ...
 
     @abstractmethod

--- a/protostar/configuration_file/configuration_file_v1.py
+++ b/protostar/configuration_file/configuration_file_v1.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Union
 
-from protostar.utils.protostar_directory import VersionManager, VersionType
+from protostar.self import ProtostarVersion, parse_protostar_version
 
 from .configuration_file import (
     CommandConfig,
@@ -47,7 +47,7 @@ class ConfigurationFileV1(ConfigurationFile[ConfigurationFileV1Model]):
             "migrate",
         ]
 
-    def get_min_protostar_version(self) -> Optional[VersionType]:
+    def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:
         version_str = self._configuration_file_interpreter.get_attribute(
             attribute_name="protostar_version",
             section_name="config",
@@ -55,7 +55,7 @@ class ConfigurationFileV1(ConfigurationFile[ConfigurationFileV1Model]):
         )
         if not version_str:
             return None
-        return VersionManager.parse(version_str)
+        return parse_protostar_version(version_str)
 
     def get_contract_names(self) -> list[str]:
         contract_section = self._configuration_file_interpreter.get_section(
@@ -109,7 +109,7 @@ class ConfigurationFileV1(ConfigurationFile[ConfigurationFileV1Model]):
         self,
     ) -> ConfigurationFileV1Model:
         return ConfigurationFileV1Model(
-            protostar_version=self._get_min_protostar_version_str(),
+            protostar_version=self._get_declared_protostar_version_str(),
             libs_path_str=self._get_libs_path_str(),
             contract_name_to_path_strs=self._get_contract_name_to_path_strs(),
             command_name_to_config=self._get_command_name_to_config(),
@@ -118,8 +118,8 @@ class ConfigurationFileV1(ConfigurationFile[ConfigurationFileV1Model]):
             profile_name_to_shared_command_config=self._get_profile_name_to_shared_command_config(),
         )
 
-    def _get_min_protostar_version_str(self) -> Optional[str]:
-        version = self.get_min_protostar_version()
+    def _get_declared_protostar_version_str(self) -> Optional[str]:
+        version = self.get_declared_protostar_version()
         if not version:
             return None
         return str(version)

--- a/protostar/configuration_file/configuration_file_v1_test.py
+++ b/protostar/configuration_file/configuration_file_v1_test.py
@@ -5,7 +5,7 @@ import pytest
 from protostar.configuration_file.configuration_legacy_toml_interpreter import (
     ConfigurationLegacyTOMLInterpreter,
 )
-from protostar.utils import VersionManager
+from protostar.self import parse_protostar_version
 
 from .configuration_file_v1 import (
     ConfigurationFile,
@@ -56,10 +56,10 @@ def configuration_file_fixture(
         """,
     ],
 )
-def test_retrieving_min_protostar_version(configuration_file: ConfigurationFile):
-    result = configuration_file.get_min_protostar_version()
+def test_retrieving_declared_protostar_version(configuration_file: ConfigurationFile):
+    result = configuration_file.get_declared_protostar_version()
 
-    assert result == VersionManager.parse("0.1.2")
+    assert result == parse_protostar_version("0.1.2")
 
 
 @pytest.mark.parametrize(

--- a/protostar/configuration_file/configuration_file_v2_test.py
+++ b/protostar/configuration_file/configuration_file_v2_test.py
@@ -9,7 +9,7 @@ from protostar.configuration_file.configuration_toml_content_builder import (
 from protostar.configuration_file.configuration_toml_interpreter import (
     ConfigurationTOMLInterpreter,
 )
-from protostar.utils.protostar_directory import VersionManager
+from protostar.self import parse_protostar_version
 
 from .configuration_file import (
     ConfigurationFile,
@@ -67,10 +67,10 @@ def configuration_file_fixture(project_root_path: Path, protostar_toml_content: 
     )
 
 
-def test_retrieving_min_protostar_version(configuration_file: ConfigurationFile):
-    min_protostar_version = configuration_file.get_min_protostar_version()
+def test_retrieving_declared_protostar_version(configuration_file: ConfigurationFile):
+    declared_protostar_version = configuration_file.get_declared_protostar_version()
 
-    assert min_protostar_version == VersionManager.parse("9.9.9")
+    assert declared_protostar_version == parse_protostar_version("9.9.9")
 
 
 def test_retrieving_contract_names(configuration_file: ConfigurationFile):
@@ -122,7 +122,7 @@ def test_saving_configuration(
 ):
     content_configurator = configuration_file
     configuration_file_v2_model = ConfigurationFileV2Model(
-        min_protostar_version="9.9.9",
+        protostar_version="9.9.9",
         project_config={
             "lib-path": "lib",
             "no-color": True,
@@ -163,10 +163,10 @@ def test_transforming_model_v1_into_v2():
         profile_name_to_shared_command_config={"devnet": {"arg_name": 24}},
     )
 
-    model_v2 = ConfigurationFileV2Model.from_v1(model_v1, min_protostar_version="0.4.0")
+    model_v2 = ConfigurationFileV2Model.from_v1(model_v1, protostar_version="0.4.0")
 
     assert model_v2 == ConfigurationFileV2Model(
-        min_protostar_version="0.4.0",
+        protostar_version="0.4.0",
         command_name_to_config={"deploy": {"arg_name": 21}},
         contract_name_to_path_strs={"main": ["src/main.cairo"]},
         project_config={"arg_name": 42, "lib-path": "lib"},
@@ -226,7 +226,7 @@ def test_transforming_file_v1_into_v2(protostar_toml_content: str):
         filename="_",
     ).create_file_content(
         content_builder=ConfigurationTOMLContentBuilder(),
-        model=ConfigurationFileV2Model.from_v1(model_v1, min_protostar_version="9.9.9"),
+        model=ConfigurationFileV2Model.from_v1(model_v1, protostar_version="9.9.9"),
     )
 
     assert transformed_protostar_toml == protostar_toml_content
@@ -237,7 +237,7 @@ def test_saving_in_particular_order(
 ):
     content_configurator = configuration_file
     configuration_file_v2_model = ConfigurationFileV2Model(
-        min_protostar_version="9.9.9",
+        protostar_version="9.9.9",
         project_config={
             "lib-path": "./lib",
             "cairo-path": ["bar"],

--- a/protostar/self/__init__.py
+++ b/protostar/self/__init__.py
@@ -1,3 +1,5 @@
 from .protostar_compatibility_with_project_checker import (
     DeclaredProtostarVersionProviderProtocol,
+    ProtostarVersion,
+    parse_protostar_version,
 )

--- a/protostar/self/__init__.py
+++ b/protostar/self/__init__.py
@@ -1,0 +1,3 @@
+from .protostar_compatibility_with_project_checker import (
+    DeclaredProtostarVersionProviderProtocol,
+)

--- a/protostar/self/protostar_compatibility_with_project_checker.py
+++ b/protostar/self/protostar_compatibility_with_project_checker.py
@@ -40,7 +40,6 @@ class ProtostarCompatibilityWithProjectChecker:
             and declared_protostar_version.micro <= protostar_version.micro
         ):
             return CompatibilityCheckResult.COMPATIBLE
-        else:
-            if declared_protostar_version < protostar_version:
-                return CompatibilityCheckResult.OUTDATED_DECLARED_VERSION
+        if declared_protostar_version < protostar_version:
+            return CompatibilityCheckResult.OUTDATED_DECLARED_VERSION
         return CompatibilityCheckResult.OUTDATED_PROTOSTAR

--- a/protostar/self/protostar_compatibility_with_project_checker.py
+++ b/protostar/self/protostar_compatibility_with_project_checker.py
@@ -1,0 +1,26 @@
+from typing import Protocol
+
+from protostar.utils.protostar_directory import VersionType
+
+
+class DeclaredProtostarVersionProvider(Protocol):
+    def get_declared_protostar_version(self) -> VersionType:
+        ...
+
+
+class ProtostarVersionProvider(Protocol):
+    def get_protostar_version(self) -> VersionType:
+        ...
+
+
+class ProtostarCompatibilityWithProjectChecker:
+    def __init__(
+        self,
+        protostar_version_provider: ProtostarVersionProvider,
+        declared_protostar_version_provider: DeclaredProtostarVersionProvider,
+    ) -> None:
+        self._protostar_version_provider = protostar_version_provider
+        self._declared_protostar_version_provider = declared_protostar_version_provider
+
+    def check_backward_and_forward_compatibility(self) -> bool:
+        return True

--- a/protostar/self/protostar_compatibility_with_project_checker.py
+++ b/protostar/self/protostar_compatibility_with_project_checker.py
@@ -4,12 +4,12 @@ from typing import Protocol
 from packaging.version import Version
 
 
-class DeclaredProtostarVersionProvider(Protocol):
+class DeclaredProtostarVersionProviderProtocol(Protocol):
     def get_declared_protostar_version(self) -> Version:
         ...
 
 
-class ProtostarVersionProvider(Protocol):
+class ProtostarVersionProviderProtocol(Protocol):
     def get_protostar_version(self) -> Version:
         ...
 
@@ -23,8 +23,8 @@ class CompatibilityCheckResult(Enum):
 class ProtostarCompatibilityWithProjectChecker:
     def __init__(
         self,
-        protostar_version_provider: ProtostarVersionProvider,
-        declared_protostar_version_provider: DeclaredProtostarVersionProvider,
+        protostar_version_provider: ProtostarVersionProviderProtocol,
+        declared_protostar_version_provider: DeclaredProtostarVersionProviderProtocol,
     ) -> None:
         self._protostar_version_provider = protostar_version_provider
         self._declared_protostar_version_provider = declared_protostar_version_provider

--- a/protostar/self/protostar_compatibility_with_project_checker.py
+++ b/protostar/self/protostar_compatibility_with_project_checker.py
@@ -1,16 +1,18 @@
 from enum import Enum, auto
-from typing import Protocol
+from typing import Optional, Protocol
 
-from packaging.version import Version
+from packaging import version
+
+ProtostarVersion = version.Version
 
 
 class DeclaredProtostarVersionProviderProtocol(Protocol):
-    def get_declared_protostar_version(self) -> Version:
+    def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:
         ...
 
 
 class ProtostarVersionProviderProtocol(Protocol):
-    def get_protostar_version(self) -> Version:
+    def get_protostar_version(self) -> ProtostarVersion:
         ...
 
 
@@ -18,6 +20,7 @@ class CompatibilityCheckResult(Enum):
     COMPATIBLE = auto()
     OUTDATED_PROTOSTAR = auto()
     OUTDATED_DECLARED_VERSION = auto()
+    FAILURE = auto()
 
 
 class ProtostarCompatibilityWithProjectChecker:
@@ -34,6 +37,8 @@ class ProtostarCompatibilityWithProjectChecker:
         declared_protostar_version = (
             self._declared_protostar_version_provider.get_declared_protostar_version()
         )
+        if declared_protostar_version is None:
+            return CompatibilityCheckResult.FAILURE
         if (
             declared_protostar_version.major == protostar_version.major
             and declared_protostar_version.minor == protostar_version.minor
@@ -43,3 +48,9 @@ class ProtostarCompatibilityWithProjectChecker:
         if declared_protostar_version < protostar_version:
             return CompatibilityCheckResult.OUTDATED_DECLARED_VERSION
         return CompatibilityCheckResult.OUTDATED_PROTOSTAR
+
+
+def parse_protostar_version(value: str) -> ProtostarVersion:
+    result = version.parse(value)
+    assert isinstance(result, ProtostarVersion)
+    return result

--- a/protostar/self/protostar_compatibility_with_project_checker.py
+++ b/protostar/self/protostar_compatibility_with_project_checker.py
@@ -1,16 +1,23 @@
+from enum import Enum, auto
 from typing import Protocol
 
-from protostar.utils.protostar_directory import VersionType
+from packaging.version import Version
 
 
 class DeclaredProtostarVersionProvider(Protocol):
-    def get_declared_protostar_version(self) -> VersionType:
+    def get_declared_protostar_version(self) -> Version:
         ...
 
 
 class ProtostarVersionProvider(Protocol):
-    def get_protostar_version(self) -> VersionType:
+    def get_protostar_version(self) -> Version:
         ...
+
+
+class CompatibilityCheckResult(Enum):
+    COMPATIBLE = auto()
+    OUTDATED_PROTOSTAR = auto()
+    OUTDATED_DECLARED_VERSION = auto()
 
 
 class ProtostarCompatibilityWithProjectChecker:
@@ -22,5 +29,18 @@ class ProtostarCompatibilityWithProjectChecker:
         self._protostar_version_provider = protostar_version_provider
         self._declared_protostar_version_provider = declared_protostar_version_provider
 
-    def check_backward_and_forward_compatibility(self) -> bool:
-        return True
+    def check_compatibility(self) -> CompatibilityCheckResult:
+        protostar_version = self._protostar_version_provider.get_protostar_version()
+        declared_protostar_version = (
+            self._declared_protostar_version_provider.get_declared_protostar_version()
+        )
+        if (
+            declared_protostar_version.major == protostar_version.major
+            and declared_protostar_version.minor == protostar_version.minor
+            and declared_protostar_version.micro <= protostar_version.micro
+        ):
+            return CompatibilityCheckResult.COMPATIBLE
+        else:
+            if declared_protostar_version < protostar_version:
+                return CompatibilityCheckResult.OUTDATED_DECLARED_VERSION
+        return CompatibilityCheckResult.OUTDATED_PROTOSTAR

--- a/protostar/self/protostar_compatibility_with_project_checker_test.py
+++ b/protostar/self/protostar_compatibility_with_project_checker_test.py
@@ -1,11 +1,11 @@
 import pytest
-from packaging import version
 
 from .protostar_compatibility_with_project_checker import (
     CompatibilityCheckResult,
     DeclaredProtostarVersionProviderProtocol,
     ProtostarCompatibilityWithProjectChecker,
     ProtostarVersionProviderProtocol,
+    parse_protostar_version,
 )
 
 
@@ -14,9 +14,7 @@ class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProviderPro
         self._declared_protostar_version_str = declared_protostar_version_str
 
     def get_declared_protostar_version(self):
-        result = version.parse(self._declared_protostar_version_str)
-        assert isinstance(result, version.Version)
-        return result
+        return parse_protostar_version(self._declared_protostar_version_str)
 
 
 class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
@@ -24,9 +22,7 @@ class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
         self._protostar_version_str = protostar_version_str
 
     def get_protostar_version(self):
-        result = version.parse(self._protostar_version_str)
-        assert isinstance(result, version.Version)
-        return result
+        return parse_protostar_version(self._protostar_version_str)
 
 
 @pytest.fixture(name="declared_protostar_version")

--- a/protostar/self/protostar_compatibility_with_project_checker_test.py
+++ b/protostar/self/protostar_compatibility_with_project_checker_test.py
@@ -3,13 +3,13 @@ from packaging import version
 
 from .protostar_compatibility_with_project_checker import (
     CompatibilityCheckResult,
-    DeclaredProtostarVersionProvider,
+    DeclaredProtostarVersionProviderProtocol,
     ProtostarCompatibilityWithProjectChecker,
-    ProtostarVersionProvider,
+    ProtostarVersionProviderProtocol,
 )
 
 
-class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProvider):
+class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProviderProtocol):
     def __init__(self, declared_protostar_version_str: str):
         self._declared_protostar_version_str = declared_protostar_version_str
 
@@ -19,7 +19,7 @@ class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProvider):
         return result
 
 
-class ProtostarVersionProviderDouble(ProtostarVersionProvider):
+class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
     def __init__(self, protostar_version_str: str):
         self._protostar_version_str = protostar_version_str
 
@@ -62,8 +62,8 @@ def protostar_version_provider_fixture(protostar_version: str):
     ),
 )
 def test_compatibility(
-    declared_protostar_version_provider: DeclaredProtostarVersionProvider,
-    protostar_version_provider: ProtostarVersionProvider,
+    declared_protostar_version_provider: DeclaredProtostarVersionProviderProtocol,
+    protostar_version_provider: ProtostarVersionProviderProtocol,
     is_compatible: bool,
 ):
     compatibility_checker = ProtostarCompatibilityWithProjectChecker(

--- a/protostar/self/protostar_compatibility_with_project_checker_test.py
+++ b/protostar/self/protostar_compatibility_with_project_checker_test.py
@@ -1,0 +1,66 @@
+import pytest
+
+from protostar.utils import VersionManager
+
+from .protostar_compatibility_with_project_checker import (
+    DeclaredProtostarVersionProvider,
+    ProtostarCompatibilityWithProjectChecker,
+    ProtostarVersionProvider,
+)
+
+
+class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProvider):
+    def __init__(self, declared_protostar_version_str: str):
+        self._declared_protostar_version_str = declared_protostar_version_str
+
+    def get_declared_protostar_version(self):
+        return VersionManager.parse(self._declared_protostar_version_str)
+
+
+class ProtostarVersionProviderDouble(ProtostarVersionProvider):
+    def __init__(self, protostar_version_str: str):
+        self._protostar_version_str = protostar_version_str
+
+    def get_protostar_version(self):
+        return VersionManager.parse(self._protostar_version_str)
+
+
+@pytest.fixture(name="declared_protostar_version")
+def declared_protostar_version_fixture() -> str:
+    assert False, "Not parametrized"
+
+
+@pytest.fixture(name="declared_protostar_version_provider")
+def declared_protostar_version_provider_fixture(declared_protostar_version: str):
+    return DeclaredProtostarVersionProviderDouble(declared_protostar_version)
+
+
+@pytest.fixture(name="protostar_version")
+def protostar_version_fixture() -> str:
+    assert False, "Not parametrized"
+
+
+@pytest.fixture(name="protostar_version_provider")
+def protostar_version_provider_fixture(protostar_version: str):
+    return ProtostarVersionProviderDouble(protostar_version)
+
+
+@pytest.mark.parametrize(
+    "protostar_version, declared_protostar_version",
+    (
+        ("0.1.2", "0.1.2"),
+        ("0.1.2", "0.1.1"),
+    ),
+)
+def test_compatibility(
+    declared_protostar_version_provider: DeclaredProtostarVersionProvider,
+    protostar_version_provider: ProtostarVersionProvider,
+):
+    compatibility_checker = ProtostarCompatibilityWithProjectChecker(
+        protostar_version_provider,
+        declared_protostar_version_provider,
+    )
+
+    is_compatible = compatibility_checker.check_backward_and_forward_compatibility()
+
+    assert is_compatible

--- a/protostar/self/protostar_compatibility_with_project_checker_test.py
+++ b/protostar/self/protostar_compatibility_with_project_checker_test.py
@@ -25,19 +25,9 @@ class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
         return parse_protostar_version(self._protostar_version_str)
 
 
-@pytest.fixture(name="declared_protostar_version")
-def declared_protostar_version_fixture() -> str:
-    assert False, "Not parametrized"
-
-
 @pytest.fixture(name="declared_protostar_version_provider")
 def declared_protostar_version_provider_fixture(declared_protostar_version: str):
     return DeclaredProtostarVersionProviderDouble(declared_protostar_version)
-
-
-@pytest.fixture(name="protostar_version")
-def protostar_version_fixture() -> str:
-    assert False, "Not parametrized"
 
 
 @pytest.fixture(name="protostar_version_provider")


### PR DESCRIPTION
Currently, `protostar_version` is not properly handled by Protostar. It shouldn't be used to detect the version of the configuration file (v1, v2), but help a development team that uses Protostar to use compatible versions.

### Use case
Let's say we introduce a new cheatcode in Protostar v0.5. Alice upgraded Protostar and uses Protostar v0.5. Bob uses Protostar v0.4. Alice uses the new cheatcode and integrates her code with the mainline. Bob pulls the mainline and runs the code that uses the new cheatcode.

#### Note:
We should bump the minor (not micro) if forward compatibility is no preserved (e.g. new cheatcode).

### Current behavior
Protostar crashes for Bob. 

### Expected behavior
1. Protostar tells Alice to update the declared version in the configuration file.
2. Protostar tells Bob to upgrade Protostar.

