### PR TITLE
Redesigning `protostar.toml` 7 — `ConfigurationFileFactory`

### DIFF
--- a/protostar/configuration_file/configuration_file_factory.py
+++ b/protostar/configuration_file/configuration_file_factory.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Optional
 
+from protostar.protostar_exception import ProtostarException
+
 from .configuration_file import ConfigurationFile
 from .configuration_file_v1 import ConfigurationFileV1
 from .configuration_file_v2 import ConfigurationFileV2
@@ -25,8 +27,18 @@ class ConfigurationFileFactory:
         if configuration_file_v2:
             return configuration_file_v2
 
-        return self._create_configuration_toml_v1(
+        configuration_file_v1 = self._create_configuration_toml_v1(
             protostar_toml_path, protostar_toml_content
+        )
+        if configuration_file_v1:
+            return configuration_file_v1
+
+        raise ProtostarException(
+            f"{protostar_toml_path} must specify `protostar-version` for example:\n"
+            """
+            [project]
+            protostar-version = ?.?.?
+            """,
         )
 
     def _create_configuration_toml_v2(

--- a/protostar/configuration_file/configuration_file_factory.py
+++ b/protostar/configuration_file/configuration_file_factory.py
@@ -2,11 +2,68 @@ from pathlib import Path
 from typing import Optional
 
 from .configuration_file import ConfigurationFile
+from .configuration_file_v1 import ConfigurationFileV1
+from .configuration_file_v2 import ConfigurationFileV2
+from .configuration_legacy_toml_interpreter import ConfigurationLegacyTOMLInterpreter
+from .configuration_toml_interpreter import ConfigurationTOMLInterpreter
 
 
 class ConfigurationFileFactory:
-    def __init__(self, cwd: Path) -> None:
+    def __init__(self, cwd: Path, project_root_path: Path) -> None:
         self._cwd = cwd
+        self._project_root_path = project_root_path
 
     def create(self) -> Optional[ConfigurationFile]:
+        protostar_toml_path = self._search_upwards_protostar_toml_path()
+        if protostar_toml_path is None:
+            return None
+        protostar_toml_content = protostar_toml_path.read_text()
+
+        configuration_file_v2 = self._create_configuration_toml_v2(
+            protostar_toml_path, protostar_toml_content
+        )
+        if configuration_file_v2:
+            return configuration_file_v2
+
+        return self._create_configuration_toml_v1(
+            protostar_toml_path, protostar_toml_content
+        )
+
+    def _create_configuration_toml_v2(
+        self, protostar_toml_path: Path, protostar_toml_content: str
+    ):
+        configuration_file_v2 = ConfigurationFileV2(
+            project_root_path=self._project_root_path,
+            configuration_file_interpreter=ConfigurationTOMLInterpreter(
+                file_content=protostar_toml_content
+            ),
+            filename=protostar_toml_path.name,
+        )
+        if configuration_file_v2.get_declared_protostar_version() is not None:
+            return configuration_file_v2
+        return None
+
+    def _create_configuration_toml_v1(
+        self, protostar_toml_path: Path, protostar_toml_content: str
+    ):
+        configuration_file_v1 = ConfigurationFileV1(
+            project_root_path=self._project_root_path,
+            configuration_file_interpreter=ConfigurationLegacyTOMLInterpreter(
+                file_content=protostar_toml_content
+            ),
+            filename=protostar_toml_path.name,
+        )
+        if configuration_file_v1.get_declared_protostar_version() is not None:
+            return configuration_file_v1
+        return None
+
+    def _search_upwards_protostar_toml_path(self) -> Optional[Path]:
+        directory_path = self._cwd
+        root_path = Path(directory_path.root)
+        while directory_path != root_path:
+            for file_path in directory_path.iterdir():
+                if "protostar.toml" == file_path.name:
+                    return directory_path / "protostar.toml"
+
+            directory_path = directory_path.parent
         return None

--- a/protostar/configuration_file/configuration_file_factory.py
+++ b/protostar/configuration_file/configuration_file_factory.py
@@ -9,9 +9,8 @@ from .configuration_toml_interpreter import ConfigurationTOMLInterpreter
 
 
 class ConfigurationFileFactory:
-    def __init__(self, cwd: Path, project_root_path: Path) -> None:
+    def __init__(self, cwd: Path) -> None:
         self._cwd = cwd
-        self._project_root_path = project_root_path
 
     def create(self) -> Optional[ConfigurationFile]:
         protostar_toml_path = self._search_upwards_protostar_toml_path()
@@ -20,7 +19,8 @@ class ConfigurationFileFactory:
         protostar_toml_content = protostar_toml_path.read_text()
 
         configuration_file_v2 = self._create_configuration_toml_v2(
-            protostar_toml_path, protostar_toml_content
+            protostar_toml_path,
+            protostar_toml_content,
         )
         if configuration_file_v2:
             return configuration_file_v2
@@ -30,10 +30,12 @@ class ConfigurationFileFactory:
         )
 
     def _create_configuration_toml_v2(
-        self, protostar_toml_path: Path, protostar_toml_content: str
+        self,
+        protostar_toml_path: Path,
+        protostar_toml_content: str,
     ):
         configuration_file_v2 = ConfigurationFileV2(
-            project_root_path=self._project_root_path,
+            project_root_path=protostar_toml_path,
             configuration_file_interpreter=ConfigurationTOMLInterpreter(
                 file_content=protostar_toml_content
             ),
@@ -44,10 +46,12 @@ class ConfigurationFileFactory:
         return None
 
     def _create_configuration_toml_v1(
-        self, protostar_toml_path: Path, protostar_toml_content: str
+        self,
+        protostar_toml_path: Path,
+        protostar_toml_content: str,
     ):
         configuration_file_v1 = ConfigurationFileV1(
-            project_root_path=self._project_root_path,
+            project_root_path=protostar_toml_path,
             configuration_file_interpreter=ConfigurationLegacyTOMLInterpreter(
                 file_content=protostar_toml_content
             ),

--- a/protostar/configuration_file/configuration_file_factory.py
+++ b/protostar/configuration_file/configuration_file_factory.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from typing import Optional
+
+from .configuration_file import ConfigurationFile
+
+
+class ConfigurationFileFactory:
+    def __init__(self, cwd: Path) -> None:
+        self._cwd = cwd
+
+    def create(self) -> Optional[ConfigurationFile]:
+        return None

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 
+from tests.conftest import create_file_structure
+
 from .configuration_file_factory import ConfigurationFileFactory
+from .configuration_file_v1 import ConfigurationFileV1
+
+PROTOSTAR_TOML_V1_CONTENT = """
+["protostar.config"]
+protostar_version = 0.4.0
+"""
 
 
 def test_not_finding_configuration_file():
@@ -9,3 +17,18 @@ def test_not_finding_configuration_file():
     configuration_file = configuration_file_factory.create()
 
     assert configuration_file is None
+
+
+def test_creating_configuration_file_v1_from_subdirectory(tmp_path: Path):
+    create_file_structure(
+        root_path=tmp_path,
+        file_structure_schema={
+            "protostar.toml": PROTOSTAR_TOML_V1_CONTENT,
+            "src": {},
+        },
+    )
+    configuration_file_factory = ConfigurationFileFactory(cwd=tmp_path / "src")
+
+    configuration_file_v1 = configuration_file_factory.create()
+
+    assert configuration_file_v1 is ConfigurationFileV1

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -58,3 +58,13 @@ def test_not_detecting_configuration_file(tmp_path: Path):
 
     with pytest.raises(ProtostarException, match="protostar-version"):
         configuration_file_factory.create()
+
+
+def test_handling_parsing_error(tmp_path: Path):
+    (tmp_path / "protostar.toml").write_text("[project")
+    configuration_file_factory = ConfigurationFileFactory(cwd=tmp_path)
+
+    with pytest.raises(
+        ProtostarException, match="Couldn't parse the configuration file"
+    ):
+        configuration_file_factory.create()

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -4,10 +4,16 @@ from tests.conftest import create_file_structure
 
 from .configuration_file_factory import ConfigurationFileFactory
 from .configuration_file_v1 import ConfigurationFileV1
+from .configuration_file_v2 import ConfigurationFileV2
 
 PROTOSTAR_TOML_V1_CONTENT = """
 ["protostar.config"]
 protostar_version = "0.4.0"
+"""
+
+PROTOSTAR_TOML_V2_CONTENT = """
+[project]
+protostar_version = "0.5.0"
 """
 
 
@@ -32,3 +38,18 @@ def test_creating_configuration_file_v1_from_subdirectory(tmp_path: Path):
     configuration_file_v1 = configuration_file_factory.create()
 
     assert isinstance(configuration_file_v1, ConfigurationFileV1)
+
+
+def test_creating_configuration_file_v2_from_subdirectory(tmp_path: Path):
+    create_file_structure(
+        root_path=tmp_path,
+        file_structure_schema={
+            "protostar.toml": PROTOSTAR_TOML_V2_CONTENT,
+            "src": {},
+        },
+    )
+    configuration_file_factory = ConfigurationFileFactory(cwd=tmp_path / "src")
+
+    configuration_file_v2 = configuration_file_factory.create()
+
+    assert isinstance(configuration_file_v2, ConfigurationFileV2)

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import pytest
+
+from protostar.protostar_exception import ProtostarException
 from tests.conftest import create_file_structure
 
 from .configuration_file_factory import ConfigurationFileFactory
@@ -41,15 +44,17 @@ def test_creating_configuration_file_v1_from_subdirectory(tmp_path: Path):
 
 
 def test_creating_configuration_file_v2_from_subdirectory(tmp_path: Path):
-    create_file_structure(
-        root_path=tmp_path,
-        file_structure_schema={
-            "protostar.toml": PROTOSTAR_TOML_V2_CONTENT,
-            "src": {},
-        },
-    )
-    configuration_file_factory = ConfigurationFileFactory(cwd=tmp_path / "src")
+    (tmp_path / "protostar.toml").write_text(PROTOSTAR_TOML_V2_CONTENT)
+    configuration_file_factory = ConfigurationFileFactory(cwd=tmp_path)
 
     configuration_file_v2 = configuration_file_factory.create()
 
     assert isinstance(configuration_file_v2, ConfigurationFileV2)
+
+
+def test_not_detecting_configuration_file(tmp_path: Path):
+    (tmp_path / "protostar.toml").write_text("")
+    configuration_file_factory = ConfigurationFileFactory(cwd=tmp_path)
+
+    with pytest.raises(ProtostarException, match="protostar-version"):
+        configuration_file_factory.create()

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -7,7 +7,7 @@ from .configuration_file_v1 import ConfigurationFileV1
 
 PROTOSTAR_TOML_V1_CONTENT = """
 ["protostar.config"]
-protostar_version = 0.4.0
+protostar_version = "0.4.0"
 """
 
 
@@ -31,4 +31,4 @@ def test_creating_configuration_file_v1_from_subdirectory(tmp_path: Path):
 
     configuration_file_v1 = configuration_file_factory.create()
 
-    assert configuration_file_v1 is ConfigurationFileV1
+    assert isinstance(configuration_file_v1, ConfigurationFileV1)

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from .configuration_file_factory import ConfigurationFileFactory
+
+
+def test_not_finding_configuration_file():
+    configuration_file_factory = ConfigurationFileFactory(cwd=Path())
+
+    configuration_file = configuration_file_factory.create()
+
+    assert configuration_file is None

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -13,7 +13,7 @@ protostar_version = "0.4.0"
 
 PROTOSTAR_TOML_V2_CONTENT = """
 [project]
-protostar_version = "0.5.0"
+protostar-version = "0.5.0"
 """
 
 

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -56,12 +56,12 @@ class ConfigurationFileV2(
     def __init__(
         self,
         project_root_path: Path,
-        configuration_file_reader: ConfigurationFileInterpreter,
+        configuration_file_interpreter: ConfigurationFileInterpreter,
         filename: str,
     ) -> None:
         super().__init__()
         self._project_root_path = project_root_path
-        self._configuration_file_reader = configuration_file_reader
+        self._configuration_file_reader = configuration_file_interpreter
         self._filename = filename
 
     def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -66,7 +66,7 @@ class ConfigurationFileV2(
 
     def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:
         version_str = self._configuration_file_reader.get_attribute(
-            attribute_name="min-protostar-version", section_name="project"
+            attribute_name="protostar-version", section_name="project"
         )
         if not version_str:
             return None
@@ -145,7 +145,7 @@ class ConfigurationFileV2(
     @staticmethod
     def _prepare_project_section_data(model: ConfigurationFileV2Model) -> dict:
         project_config_section = {}
-        project_config_section["min-protostar-version"] = str(model.protostar_version)
+        project_config_section["protostar-version"] = str(model.protostar_version)
         project_config_section: dict = {
             **project_config_section,
             **model.project_config,

--- a/protostar/configuration_file/configuration_file_v2_test.py
+++ b/protostar/configuration_file/configuration_file_v2_test.py
@@ -62,7 +62,7 @@ def configuration_file_fixture(project_root_path: Path, protostar_toml_content: 
     )
     return ConfigurationFileV2(
         project_root_path=project_root_path,
-        configuration_file_reader=configuration_toml_reader,
+        configuration_file_interpreter=configuration_toml_reader,
         filename=protostar_toml_path.name,
     )
 
@@ -219,7 +219,7 @@ def test_transforming_file_v1_into_v2(protostar_toml_content: str):
     ).read()
 
     transformed_protostar_toml = ConfigurationFileV2(
-        configuration_file_reader=ConfigurationTOMLInterpreter(
+        configuration_file_interpreter=ConfigurationTOMLInterpreter(
             file_content=old_protostar_toml_content,
         ),
         project_root_path=Path(),

--- a/protostar/configuration_file/configuration_file_v2_test.py
+++ b/protostar/configuration_file/configuration_file_v2_test.py
@@ -26,7 +26,7 @@ def protostar_toml_content_fixture() -> str:
     return textwrap.dedent(
         """\
         [project]
-        min-protostar-version = "9.9.9"
+        protostar-version = "9.9.9"
         lib-path = "lib"
         no-color = true
         network = "devnet1"

--- a/protostar/configuration_file/configuration_legacy_toml_interpreter.py
+++ b/protostar/configuration_file/configuration_legacy_toml_interpreter.py
@@ -3,6 +3,8 @@ from typing import Any, Optional
 import flatdict
 import tomli
 
+from protostar.protostar_exception import ProtostarException
+
 from .configuration_file_interpreter import ConfigurationFileInterpreter
 
 
@@ -18,15 +20,22 @@ class ConfigurationLegacyTOMLInterpreter(ConfigurationFileInterpreter):
         profile_name: Optional[str] = None,
         section_namespace: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
-        section_name = (
-            f"{section_namespace}.{section_name}" if section_namespace else section_name
-        )
-        protostar_toml_dict = self._get_flat_dict_representation()
-        if profile_name:
-            section_name = f"profile.{profile_name}.{section_name}"
-        if section_name not in protostar_toml_dict:
-            return None
-        return protostar_toml_dict[section_name]
+        try:
+            section_name = (
+                f"{section_namespace}.{section_name}"
+                if section_namespace
+                else section_name
+            )
+            protostar_toml_dict = self._get_flat_dict_representation()
+            if profile_name:
+                section_name = f"profile.{profile_name}.{section_name}"
+            if section_name not in protostar_toml_dict:
+                return None
+            return protostar_toml_dict[section_name]
+        except Exception as ex:
+            raise ProtostarException(
+                message="Couldn't parse the configuration file", details=str(ex)
+            ) from ex
 
     def _get_flat_dict_representation(self):
         protostar_toml_dict = tomli.loads(self._file_content)

--- a/protostar/configuration_file/configuration_toml_interpreter.py
+++ b/protostar/configuration_file/configuration_toml_interpreter.py
@@ -1,7 +1,10 @@
 from typing import Any, Optional
 
 import tomlkit
+from tomlkit.exceptions import ParseError
 from tomlkit.toml_document import TOMLDocument
+
+from protostar.protostar_exception import ProtostarException
 
 from .configuration_file_interpreter import ConfigurationFileInterpreter
 
@@ -17,17 +20,22 @@ class ConfigurationTOMLInterpreter(ConfigurationFileInterpreter):
         profile_name: Optional[str] = None,
         section_namespace: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
-        doc = self._get_doc()
-        section_parent = self._get_section_parent(
-            dct=doc.value,
-            profile_name=profile_name,
-            section_namespace=section_namespace,
-        )
-        if not section_parent:
-            return None
-        if section_name not in section_parent:
-            return None
-        return section_parent[section_name]
+        try:
+            doc = self._get_doc()
+            section_parent = self._get_section_parent(
+                dct=doc.value,
+                profile_name=profile_name,
+                section_namespace=section_namespace,
+            )
+            if not section_parent:
+                return None
+            if section_name not in section_parent:
+                return None
+            return section_parent[section_name]
+        except ParseError as ex:
+            raise ProtostarException(
+                message="Couldn't parse the configuration file", details=str(ex)
+            ) from ex
 
     def _get_doc(self) -> TOMLDocument:
         return tomlkit.loads(self._content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import subprocess
 import time
+from pathlib import Path
 from socket import socket as Socket
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Union
 
 import pytest
 import requests
@@ -71,3 +72,19 @@ def signing_credentials_fixture() -> Credentials:  # The same account is generat
         testnet_account_private_key,
         testnet_account_address,
     )
+
+
+PathStr = str
+FileContent = str
+FileStructureSchema = dict[PathStr, Union["FileStructureSchema", FileContent]]
+
+
+def create_file_structure(root_path: Path, file_structure_schema: FileStructureSchema):
+    for path_str, composite in file_structure_schema.items():
+        if isinstance(composite, str):
+            file_content = composite
+            Path(path_str).write_text(file_content)
+        else:
+            new_root_path = root_path / Path(path_str)
+            new_root_path.mkdir()
+            create_file_structure(new_root_path, file_structure_schema=composite)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,8 @@ def create_file_structure(root_path: Path, file_structure_schema: FileStructureS
     for path_str, composite in file_structure_schema.items():
         if isinstance(composite, str):
             file_content = composite
-            Path(path_str).write_text(file_content)
+            # pylint: disable=unspecified-encoding
+            (root_path / Path(path_str)).write_text(file_content)
         else:
             new_root_path = root_path / Path(path_str)
             new_root_path.mkdir()


### PR DESCRIPTION
`ConfigurationFileFactory` builds the proper version of the `ConfigurationFile`.

This PR doesn't change the Protostar logic yet. I'll merge this PR without review on 27 September at 3 pm.