### PR TITLE
Redesigning `protostar.toml` 9 — Migrator

### DIFF
--- a/protostar/commands/migrate_configuration_file_command.py
+++ b/protostar/commands/migrate_configuration_file_command.py
@@ -1,0 +1,36 @@
+from logging import Logger
+from typing import List, Optional
+
+from protostar.cli import Command
+from protostar.configuration_file import ConfigurationFileMigratorProtocol
+
+
+class MigrateConfigurationFileCommand(Command):
+    def __init__(
+        self,
+        logger: Logger,
+        configuration_file_migrator: ConfigurationFileMigratorProtocol,
+    ) -> None:
+        super().__init__()
+        self._logger = logger
+        self._configuration_file_migrator = configuration_file_migrator
+
+    @property
+    def name(self) -> str:
+        return "migrate-configuration-file"
+
+    @property
+    def description(self) -> str:
+        return "Migrate protostar.toml to the new version introduced in Protostar v0.5"
+
+    @property
+    def example(self) -> Optional[str]:
+        return None
+
+    @property
+    def arguments(self) -> List[Command.Argument]:
+        return []
+
+    async def run(self, args) -> None:
+        self._configuration_file_migrator.run()
+        self._logger.info("The configuration file was migrated successfully.")

--- a/protostar/configuration_file/__init__.py
+++ b/protostar/configuration_file/__init__.py
@@ -1,1 +1,3 @@
+from .configuration_file import ConfigurationFileMigratorProtocol
 from .configuration_file_v1 import CommandNamesProviderProtocol
+from .configuration_file_v2_migrator import ConfigurationFileV2Migrator

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Generic, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, Protocol, TypeVar, Union
 
 from protostar.protostar_exception import ProtostarException
 from protostar.self import DeclaredProtostarVersionProviderProtocol, ProtostarVersion
@@ -89,3 +89,8 @@ class ContractNameNotFoundException(ProtostarException):
         super().__init__(
             f"Couldn't find `{contract_name}` in `{expected_declaration_location}`"
         )
+
+
+class ConfigurationFileMigratorProtocol(Protocol):
+    def run(self) -> None:
+        pass

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -26,12 +26,13 @@ class ConfigurationFileContentBuilder(ABC):
         data: dict[str, Any],
         profile_name: Optional[str] = None,
     ) -> None:
-        pass
+        ...
 
     @abstractmethod
     def build(self) -> str:
         ...
 
+    @abstractmethod
     def get_file_extension(self) -> str:
         ...
 

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -37,7 +37,6 @@ class ConfigurationFileContentConfigurator(Generic[ConfigurationFileModelT]):
     @abstractmethod
     def create_file_content(
         self,
-        content_builder: ConfigurationFileContentBuilder,
         model: ConfigurationFileModelT,
     ) -> str:
         ...

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -33,7 +33,7 @@ class ConfigurationFileContentBuilder(ABC):
         ...
 
     @abstractmethod
-    def get_file_extension(self) -> str:
+    def get_content_format(self) -> str:
         ...
 
 

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -50,6 +50,10 @@ class ConfigurationFile(
         ...
 
     @abstractmethod
+    def get_filepath(self) -> Path:
+        ...
+
+    @abstractmethod
     def get_contract_names(self) -> list[str]:
         ...
 

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -37,7 +37,7 @@ class ConfigurationFileContentBuilder(ABC):
         ...
 
 
-class ConfigurationFileContentConfigurator(Generic[ConfigurationFileModelT]):
+class ConfigurationFileContentFactory(Generic[ConfigurationFileModelT]):
     @abstractmethod
     def create_file_content(
         self,

--- a/protostar/configuration_file/configuration_file.py
+++ b/protostar/configuration_file/configuration_file.py
@@ -32,6 +32,9 @@ class ConfigurationFileContentBuilder(ABC):
     def build(self) -> str:
         ...
 
+    def get_file_extension(self) -> str:
+        ...
+
 
 class ConfigurationFileContentConfigurator(Generic[ConfigurationFileModelT]):
     @abstractmethod
@@ -39,6 +42,9 @@ class ConfigurationFileContentConfigurator(Generic[ConfigurationFileModelT]):
         self,
         model: ConfigurationFileModelT,
     ) -> str:
+        ...
+
+    def get_file_extension(self) -> str:
         ...
 
 

--- a/protostar/configuration_file/configuration_file_factory.py
+++ b/protostar/configuration_file/configuration_file_factory.py
@@ -54,7 +54,7 @@ class ConfigurationFileFactory:
             configuration_file_interpreter=ConfigurationTOMLInterpreter(
                 file_content=protostar_toml_content
             ),
-            filename=protostar_toml_path.name,
+            file_path=protostar_toml_path,
         )
         if configuration_file_v2.get_declared_protostar_version() is not None:
             return configuration_file_v2
@@ -70,7 +70,7 @@ class ConfigurationFileFactory:
             configuration_file_interpreter=ConfigurationLegacyTOMLInterpreter(
                 file_content=protostar_toml_content
             ),
-            filename=protostar_toml_path.name,
+            file_path=protostar_toml_path,
             command_names_provider=self._command_names_provider,
         )
         if configuration_file_v1.get_declared_protostar_version() is not None:

--- a/protostar/configuration_file/configuration_file_factory_test.py
+++ b/protostar/configuration_file/configuration_file_factory_test.py
@@ -9,16 +9,7 @@ from tests.conftest import create_file_structure
 from .configuration_file_factory import ConfigurationFileFactory
 from .configuration_file_v1 import ConfigurationFileV1
 from .configuration_file_v2 import ConfigurationFileV2
-
-PROTOSTAR_TOML_V1_CONTENT = """
-["protostar.config"]
-protostar_version = "0.4.0"
-"""
-
-PROTOSTAR_TOML_V2_CONTENT = """
-[project]
-protostar-version = "0.5.0"
-"""
+from .conftest import PROTOSTAR_TOML_V1_CONTENT, PROTOSTAR_TOML_V2_CONTENT
 
 
 def test_not_finding_configuration_file(mocker: MockerFixture):

--- a/protostar/configuration_file/configuration_file_v1.py
+++ b/protostar/configuration_file/configuration_file_v1.py
@@ -37,14 +37,17 @@ class ConfigurationFileV1(ConfigurationFile[ConfigurationFileV1Model]):
         self,
         configuration_file_interpreter: ConfigurationFileInterpreter,
         project_root_path: Path,
-        filename: str,
+        file_path: Path,
         command_names_provider: CommandNamesProviderProtocol,
     ) -> None:
         super().__init__()
         self._configuration_file_interpreter = configuration_file_interpreter
         self._project_root_path = project_root_path
-        self._filename = filename
+        self._file_path = file_path
         self._command_names_provider = command_names_provider
+
+    def get_filepath(self) -> Path:
+        return self._file_path
 
     def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:
         version_str = self._configuration_file_interpreter.get_attribute(
@@ -69,7 +72,9 @@ class ConfigurationFileV1(ConfigurationFile[ConfigurationFileV1Model]):
             "contracts", section_namespace="protostar"
         )
         if contract_section is None or contract_name not in contract_section:
-            contracts_config_location = f'{self._filename}::["protostar.contracts"]'
+            contracts_config_location = (
+                f'{self._file_path.name}::["protostar.contracts"]'
+            )
             raise ContractNameNotFoundException(
                 contract_name,
                 expected_declaration_location=contracts_config_location,

--- a/protostar/configuration_file/configuration_file_v1_test.py
+++ b/protostar/configuration_file/configuration_file_v1_test.py
@@ -49,7 +49,7 @@ def configuration_file_fixture(
             file_content=protostar_toml_content,
         ),
         project_root_path=project_root_path,
-        filename=protostar_toml_path.name,
+        file_path=protostar_toml_path,
         command_names_provider=CommandNamesProviderDouble(),
     )
 

--- a/protostar/configuration_file/configuration_file_v1_test.py
+++ b/protostar/configuration_file/configuration_file_v1_test.py
@@ -16,7 +16,7 @@ from .configuration_file_v1 import (
 )
 
 
-class CommandNamesProviderDouble(CommandNamesProviderProtocol):
+class CommandNamesProviderStub(CommandNamesProviderProtocol):
     def get_command_names(self) -> list[str]:
         return ["deploy"]
 
@@ -50,7 +50,7 @@ def configuration_file_fixture(
         ),
         project_root_path=project_root_path,
         file_path=protostar_toml_path,
-        command_names_provider=CommandNamesProviderDouble(),
+        command_names_provider=CommandNamesProviderStub(),
     )
 
 

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -166,3 +166,6 @@ class ConfigurationFileV2ContentConfigurator(
         }
 
         return project_config_section
+
+    def get_file_extension(self) -> str:
+        return self._content_builder.get_file_extension()

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -56,12 +56,12 @@ class ConfigurationFileV2(
         self,
         project_root_path: Path,
         configuration_file_interpreter: ConfigurationFileInterpreter,
-        filename: str,
+        file_path: Path,
     ) -> None:
         super().__init__()
         self._project_root_path = project_root_path
         self._configuration_file_reader = configuration_file_interpreter
-        self._filename = filename
+        self._file_path = file_path
 
     def get_declared_protostar_version(self) -> Optional[ProtostarVersion]:
         version_str = self._configuration_file_reader.get_attribute(
@@ -70,6 +70,9 @@ class ConfigurationFileV2(
         if not version_str:
             return None
         return parse_protostar_version(version_str)
+
+    def get_filepath(self) -> Path:
+        return self._file_path
 
     def get_contract_names(self) -> list[str]:
         contract_section = self._configuration_file_reader.get_section("contracts")
@@ -82,7 +85,7 @@ class ConfigurationFileV2(
         if contract_section is None or contract_name not in contract_section:
             raise ContractNameNotFoundException(
                 contract_name,
-                expected_declaration_location=f"{self._filename}::[contracts]",
+                expected_declaration_location=f"{self._file_path.name}::[contracts]",
             )
         return [
             self._project_root_path / Path(path_str)

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -168,4 +168,4 @@ class ConfigurationFileV2ContentConfigurator(
         return project_config_section
 
     def get_file_extension(self) -> str:
-        return self._content_builder.get_file_extension()
+        return self._content_builder.get_content_format()

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -11,7 +11,7 @@ from .configuration_file import (
     CommandNameToConfig,
     ConfigurationFile,
     ConfigurationFileContentBuilder,
-    ConfigurationFileContentConfigurator,
+    ConfigurationFileContentFactory,
     ContractName,
     ContractNameNotFoundException,
     PrimitiveTypesSupportedByConfigurationFile,
@@ -112,8 +112,8 @@ class ConfigurationFileV2(
         raise NotImplementedError("Operation not supported.")
 
 
-class ConfigurationFileV2ContentConfigurator(
-    ConfigurationFileContentConfigurator[ConfigurationFileV2Model]
+class ConfigurationFileV2ContentFactory(
+    ConfigurationFileContentFactory[ConfigurationFileV2Model]
 ):
     def __init__(
         self,

--- a/protostar/configuration_file/configuration_file_v2.py
+++ b/protostar/configuration_file/configuration_file_v2.py
@@ -51,7 +51,6 @@ class ConfigurationFileV2Model:
 
 class ConfigurationFileV2(
     ConfigurationFile[ConfigurationFileV2Model],
-    ConfigurationFileContentConfigurator[ConfigurationFileV2Model],
 ):
     def __init__(
         self,
@@ -109,24 +108,36 @@ class ConfigurationFileV2(
     ) -> ConfigurationFileV2Model:
         raise NotImplementedError("Operation not supported.")
 
-    def create_file_content(
+
+class ConfigurationFileV2ContentConfigurator(
+    ConfigurationFileContentConfigurator[ConfigurationFileV2Model]
+):
+    def __init__(
         self,
         content_builder: ConfigurationFileContentBuilder,
+    ) -> None:
+        super().__init__()
+        self._content_builder = content_builder
+
+    def create_file_content(
+        self,
         model: ConfigurationFileV2Model,
     ) -> str:
-        content_builder.set_section(
+        self._content_builder.set_section(
             section_name="project", data=self._prepare_project_section_data(model)
         )
-        content_builder.set_section(
+        self._content_builder.set_section(
             section_name="contracts", data=model.contract_name_to_path_strs
         )
         for command_name, command_config in model.command_name_to_config.items():
-            content_builder.set_section(section_name=command_name, data=command_config)
+            self._content_builder.set_section(
+                section_name=command_name, data=command_config
+            )
         for (
             profile_name,
             project_config,
         ) in model.profile_name_to_project_config.items():
-            content_builder.set_section(
+            self._content_builder.set_section(
                 profile_name=profile_name, section_name="project", data=project_config
             )
         for (
@@ -134,12 +145,12 @@ class ConfigurationFileV2(
             command_name_to_config,
         ) in model.profile_name_to_commands_config.items():
             for command_name, command_config in command_name_to_config.items():
-                content_builder.set_section(
+                self._content_builder.set_section(
                     profile_name=profile_name,
                     section_name=command_name,
                     data=command_config,
                 )
-        content = content_builder.build()
+        content = self._content_builder.build()
         return content
 
     @staticmethod

--- a/protostar/configuration_file/configuration_file_v2_migrator.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator.py
@@ -46,7 +46,7 @@ class ConfigurationFileMigrator:
             file_content = self._content_configurator.create_file_content(v2_model)
             (
                 configuration_file_path.parent
-                / f"{configuration_file_path.stem}.{self._content_configurator.get_extension()}"
+                / f"{configuration_file_path.stem}.{self._content_configurator.get_file_extension()}"
             ).write_text(file_content)
             backup_file_path.unlink()
         # pylint: disable=broad-except

--- a/protostar/configuration_file/configuration_file_v2_migrator.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator.py
@@ -7,7 +7,7 @@ from .configuration_file import ConfigurationFile, ConfigurationFileMigratorProt
 from .configuration_file_v1 import ConfigurationFileV1
 from .configuration_file_v2 import (
     ConfigurationFileV2,
-    ConfigurationFileV2ContentConfigurator,
+    ConfigurationFileV2ContentFactory,
     ConfigurationFileV2Model,
 )
 
@@ -16,11 +16,11 @@ class ConfigurationFileV2Migrator(ConfigurationFileMigratorProtocol):
     def __init__(
         self,
         current_configuration_file: Optional[ConfigurationFile],
-        content_configurator: ConfigurationFileV2ContentConfigurator,
+        content_factory: ConfigurationFileV2ContentFactory,
         protostar_version_provider: ProtostarVersionProviderProtocol,
     ) -> None:
         self._current_configuration_file = current_configuration_file
-        self._content_configurator = content_configurator
+        self._content_factory = content_factory
         self._protostar_version_provider = protostar_version_provider
 
     def run(self) -> None:
@@ -37,10 +37,10 @@ class ConfigurationFileV2Migrator(ConfigurationFileMigratorProtocol):
             ccf_path.parent / f"{ccf_path.stem}_backup.{ccf_path.suffix}"
         )
         try:
-            file_content = self._content_configurator.create_file_content(v2_model)
+            file_content = self._content_factory.create_file_content(v2_model)
             (
                 ccf_path.parent
-                / f"{ccf_path.stem}.{self._content_configurator.get_file_extension()}"
+                / f"{ccf_path.stem}.{self._content_factory.get_file_extension()}"
             ).write_text(file_content)
             backup_file_path.unlink()
         # pylint: disable=broad-except

--- a/protostar/configuration_file/configuration_file_v2_migrator.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import Optional
+
+from protostar.protostar_exception import ProtostarException
+from protostar.self import ProtostarVersionProviderProtocol
+
+from .configuration_file import ConfigurationFile
+from .configuration_file_v1 import ConfigurationFileV1
+from .configuration_file_v2 import (
+    ConfigurationFileV2,
+    ConfigurationFileV2ContentConfigurator,
+    ConfigurationFileV2Model,
+)
+
+
+class ConfigurationFileMigrator:
+    def __init__(
+        self,
+        current_configuration_file: Optional[ConfigurationFile],
+        content_configurator: ConfigurationFileV2ContentConfigurator,
+        protostar_version_provider: ProtostarVersionProviderProtocol,
+    ) -> None:
+        self._current_configuration_file = current_configuration_file
+        self._content_configurator = content_configurator
+        self._protostar_version_provider = protostar_version_provider
+
+    def run(self) -> None:
+        if self._current_configuration_file is None:
+            raise ProtostarException("No configuration file was found.")
+        if isinstance(self._current_configuration_file, ConfigurationFileV2):
+            raise ProtostarException("Configuration file is already migrated.")
+        assert isinstance(self._current_configuration_file, ConfigurationFileV1)
+        v1_model = self._current_configuration_file.read()
+        v2_model = ConfigurationFileV2Model.from_v1(
+            v1_model,
+            protostar_version=str(
+                self._protostar_version_provider.get_protostar_version()
+            ),
+        )
+        configuration_file_path: Path = self._current_configuration_file.get_filepath()
+        backup_file_path = configuration_file_path.rename(
+            configuration_file_path.parent
+            / f"{configuration_file_path.stem}_backup.{configuration_file_path.suffix}"
+        )
+        try:
+            file_content = self._content_configurator.create_file_content(v2_model)
+            (
+                configuration_file_path.parent
+                / f"{configuration_file_path.stem}.{self._content_configurator.get_extension()}"
+            ).write_text(file_content)
+            backup_file_path.unlink()
+        # pylint: disable=broad-except
+        except Exception as ex:
+            backup_file_path.rename(configuration_file_path)
+            raise ProtostarException(
+                "Configuration file migration failed", details=str(ex)
+            ) from ex

--- a/protostar/configuration_file/configuration_file_v2_migrator.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 
 from protostar.protostar_exception import ProtostarException
@@ -25,34 +24,37 @@ class ConfigurationFileMigrator:
         self._protostar_version_provider = protostar_version_provider
 
     def run(self) -> None:
-        if self._current_configuration_file is None:
-            raise ConfigurationFileNotFoundException()
-        if isinstance(self._current_configuration_file, ConfigurationFileV2):
-            raise ConfigurationFileAlreadyMigratedException()
-        assert isinstance(self._current_configuration_file, ConfigurationFileV1)
-        v1_model = self._current_configuration_file.read()
+        current_configuration_file = self._validate_current_configuration_file()
+        v1_model = current_configuration_file.read()
         v2_model = ConfigurationFileV2Model.from_v1(
             v1_model,
             protostar_version=str(
                 self._protostar_version_provider.get_protostar_version()
             ),
         )
-        configuration_file_path: Path = self._current_configuration_file.get_filepath()
-        backup_file_path = configuration_file_path.rename(
-            configuration_file_path.parent
-            / f"{configuration_file_path.stem}_backup.{configuration_file_path.suffix}"
+        ccf_path = current_configuration_file.get_filepath()
+        backup_file_path = ccf_path.rename(
+            ccf_path.parent / f"{ccf_path.stem}_backup.{ccf_path.suffix}"
         )
         try:
             file_content = self._content_configurator.create_file_content(v2_model)
             (
-                configuration_file_path.parent
-                / f"{configuration_file_path.stem}.{self._content_configurator.get_file_extension()}"
+                ccf_path.parent
+                / f"{ccf_path.stem}.{self._content_configurator.get_file_extension()}"
             ).write_text(file_content)
             backup_file_path.unlink()
         # pylint: disable=broad-except
         except Exception as ex:
-            backup_file_path.rename(configuration_file_path)
+            backup_file_path.rename(ccf_path)
             raise ConfigurationFileMigrationFailed(ex) from ex
+
+    def _validate_current_configuration_file(self) -> ConfigurationFileV1:
+        if self._current_configuration_file is None:
+            raise ConfigurationFileNotFoundException()
+        if isinstance(self._current_configuration_file, ConfigurationFileV2):
+            raise ConfigurationFileAlreadyMigratedException()
+        assert isinstance(self._current_configuration_file, ConfigurationFileV1)
+        return self._current_configuration_file
 
 
 class ConfigurationFileNotFoundException(ProtostarException):

--- a/protostar/configuration_file/configuration_file_v2_migrator.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator.py
@@ -3,7 +3,7 @@ from typing import Optional
 from protostar.protostar_exception import ProtostarException
 from protostar.self import ProtostarVersionProviderProtocol
 
-from .configuration_file import ConfigurationFile
+from .configuration_file import ConfigurationFile, ConfigurationFileMigratorProtocol
 from .configuration_file_v1 import ConfigurationFileV1
 from .configuration_file_v2 import (
     ConfigurationFileV2,
@@ -12,7 +12,7 @@ from .configuration_file_v2 import (
 )
 
 
-class ConfigurationFileMigrator:
+class ConfigurationFileV2Migrator(ConfigurationFileMigratorProtocol):
     def __init__(
         self,
         current_configuration_file: Optional[ConfigurationFile],

--- a/protostar/configuration_file/configuration_file_v2_migrator_test.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator_test.py
@@ -17,7 +17,7 @@ from .configuration_file_v2 import (
 from .configuration_file_v2_migrator import (
     ConfigurationFileAlreadyMigratedException,
     ConfigurationFileMigrationFailed,
-    ConfigurationFileMigrator,
+    ConfigurationFileV2Migrator,
     ConfigurationFileNotFoundException,
 )
 from .configuration_toml_content_builder import ConfigurationTOMLContentBuilder
@@ -91,7 +91,7 @@ def migrate(
         command_names_provider=CommandNamesProviderTestDouble(command_names=[]),
     )
     configuration_file_before = configuration_file_factory.create()
-    configuration_file_v2_migrator = ConfigurationFileMigrator(
+    configuration_file_v2_migrator = ConfigurationFileV2Migrator(
         current_configuration_file=configuration_file_before,
         content_configurator=ConfigurationFileV2ContentConfigurator(
             content_builder=content_builder or ConfigurationTOMLContentBuilder()

--- a/protostar/configuration_file/configuration_file_v2_migrator_test.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator_test.py
@@ -53,6 +53,7 @@ def test_migrate_from_subdirectory(tmp_path: Path):
 def test_no_configuration_file(tmp_path: Path):
     with pytest.raises(ConfigurationFileNotFoundException):
         migrate(tmp_path)
+
     assert_file_count(tmp_path, 0)
 
 
@@ -61,16 +62,17 @@ def test_migrating_migrated_configuration_file(tmp_path: Path):
 
     with pytest.raises(ConfigurationFileAlreadyMigratedException):
         migrate(cwd=tmp_path)
+
     assert (tmp_path / "protostar.toml").read_text() == PROTOSTAR_TOML_V2_CONTENT
     assert_file_count(tmp_path, 1)
 
 
 def test_rollback(tmp_path: Path):
-    create_file_structure(tmp_path, {"protostar.toml": PROTOSTAR_TOML_V1_CONTENT})
-
     class ConfigurationFileContentBuilderTestDouble(ConfigurationTOMLContentBuilder):
         def build(self) -> str:
             raise Exception()
+
+    create_file_structure(tmp_path, {"protostar.toml": PROTOSTAR_TOML_V1_CONTENT})
 
     with pytest.raises(ConfigurationFileMigrationFailed):
         migrate(

--- a/protostar/configuration_file/configuration_file_v2_migrator_test.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator_test.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from typing import Optional, Tuple
+
+from protostar.configuration_file.configuration_file import ConfigurationFile
+from protostar.self.conftest import ProtostarVersionProviderDouble
+from tests.conftest import create_file_structure
+
+from .configuration_file_factory import ConfigurationFileFactory
+from .configuration_file_v1 import ConfigurationFileV1
+from .configuration_file_v2 import (
+    ConfigurationFileV2,
+    ConfigurationFileV2ContentConfigurator,
+)
+from .configuration_file_v2_migrator import ConfigurationFileMigrator
+from .configuration_toml_content_builder import ConfigurationTOMLContentBuilder
+from .conftest import PROTOSTAR_TOML_V1_CONTENT, CommandNamesProviderTestDouble
+
+
+def migrate(
+    cwd: Path,
+) -> Tuple[Optional[ConfigurationFile], Optional[ConfigurationFile]]:
+    configuration_file_factory = ConfigurationFileFactory(
+        cwd=cwd,
+        command_names_provider=CommandNamesProviderTestDouble(command_names=[]),
+    )
+    configuration_file_before = configuration_file_factory.create()
+    assert configuration_file_before is not None
+    configuration_file_v2_migrator = ConfigurationFileMigrator(
+        current_configuration_file=configuration_file_before,
+        content_configurator=ConfigurationFileV2ContentConfigurator(
+            content_builder=ConfigurationTOMLContentBuilder()
+        ),
+        protostar_version_provider=ProtostarVersionProviderDouble("9.9.9"),
+    )
+
+    configuration_file_v2_migrator.run()
+
+    configuration_file_after = configuration_file_factory.create()
+
+    return (configuration_file_before, configuration_file_after)
+
+
+def test_happy_case(tmp_path: Path):
+    create_file_structure(tmp_path, {"protostar.toml": PROTOSTAR_TOML_V1_CONTENT})
+
+    (before, after) = migrate(tmp_path)
+
+    assert isinstance(before, ConfigurationFileV1)
+    assert isinstance(after, ConfigurationFileV2)

--- a/protostar/configuration_file/configuration_file_v2_migrator_test.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator_test.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 
 import pytest
 
-from protostar.self.conftest import ProtostarVersionProviderDouble
+from protostar.self.conftest import FakeProtostarVersionProvider
 from tests.conftest import create_file_structure
 
 from .configuration_file import ConfigurationFile, ConfigurationFileContentBuilder
@@ -24,7 +24,7 @@ from .configuration_toml_content_builder import ConfigurationTOMLContentBuilder
 from .conftest import (
     PROTOSTAR_TOML_V1_CONTENT,
     PROTOSTAR_TOML_V2_CONTENT,
-    CommandNamesProviderTestDouble,
+    FakeCommandNamesProvider,
 )
 
 
@@ -68,16 +68,14 @@ def test_migrating_migrated_configuration_file(tmp_path: Path):
 
 
 def test_rollback(tmp_path: Path):
-    class ConfigurationFileContentBuilderTestDouble(ConfigurationTOMLContentBuilder):
+    class ConfigurationFileContentBuilderStub(ConfigurationTOMLContentBuilder):
         def build(self) -> str:
             raise Exception()
 
     create_file_structure(tmp_path, {"protostar.toml": PROTOSTAR_TOML_V1_CONTENT})
 
     with pytest.raises(ConfigurationFileMigrationFailed):
-        migrate(
-            cwd=tmp_path, content_builder=ConfigurationFileContentBuilderTestDouble()
-        )
+        migrate(cwd=tmp_path, content_builder=ConfigurationFileContentBuilderStub())
 
     assert (tmp_path / "protostar.toml").read_text() == PROTOSTAR_TOML_V1_CONTENT
     assert_file_count(tmp_path, 1)
@@ -88,7 +86,7 @@ def migrate(
 ) -> Tuple[Optional[ConfigurationFile], Optional[ConfigurationFile]]:
     configuration_file_factory = ConfigurationFileFactory(
         cwd=cwd,
-        command_names_provider=CommandNamesProviderTestDouble(command_names=[]),
+        command_names_provider=FakeCommandNamesProvider(command_names=[]),
     )
     configuration_file_before = configuration_file_factory.create()
     configuration_file_v2_migrator = ConfigurationFileV2Migrator(
@@ -96,7 +94,7 @@ def migrate(
         content_configurator=ConfigurationFileV2ContentConfigurator(
             content_builder=content_builder or ConfigurationTOMLContentBuilder()
         ),
-        protostar_version_provider=ProtostarVersionProviderDouble("9.9.9"),
+        protostar_version_provider=FakeProtostarVersionProvider("9.9.9"),
     )
 
     configuration_file_v2_migrator.run()

--- a/protostar/configuration_file/configuration_file_v2_migrator_test.py
+++ b/protostar/configuration_file/configuration_file_v2_migrator_test.py
@@ -12,7 +12,7 @@ from .configuration_file_factory import ConfigurationFileFactory
 from .configuration_file_v1 import ConfigurationFileV1
 from .configuration_file_v2 import (
     ConfigurationFileV2,
-    ConfigurationFileV2ContentConfigurator,
+    ConfigurationFileV2ContentFactory,
 )
 from .configuration_file_v2_migrator import (
     ConfigurationFileAlreadyMigratedException,
@@ -91,7 +91,7 @@ def migrate(
     configuration_file_before = configuration_file_factory.create()
     configuration_file_v2_migrator = ConfigurationFileV2Migrator(
         current_configuration_file=configuration_file_before,
-        content_configurator=ConfigurationFileV2ContentConfigurator(
+        content_factory=ConfigurationFileV2ContentFactory(
             content_builder=content_builder or ConfigurationTOMLContentBuilder()
         ),
         protostar_version_provider=FakeProtostarVersionProvider("9.9.9"),

--- a/protostar/configuration_file/configuration_file_v2_test.py
+++ b/protostar/configuration_file/configuration_file_v2_test.py
@@ -10,7 +10,7 @@ from protostar.self import parse_protostar_version
 
 from .configuration_file import (
     ConfigurationFile,
-    ConfigurationFileContentConfigurator,
+    ConfigurationFileContentFactory,
     ContractNameNotFoundException,
 )
 from .configuration_file_v1 import (
@@ -20,7 +20,7 @@ from .configuration_file_v1 import (
 )
 from .configuration_file_v2 import (
     ConfigurationFileV2,
-    ConfigurationFileV2ContentConfigurator,
+    ConfigurationFileV2ContentFactory,
     ConfigurationFileV2Model,
 )
 from .configuration_legacy_toml_interpreter import ConfigurationLegacyTOMLInterpreter
@@ -77,9 +77,9 @@ def configuration_file_fixture(project_root_path: Path, protostar_toml_content: 
     )
 
 
-@pytest.fixture(name="content_configurator")
-def content_configurator_fixture():
-    return ConfigurationFileV2ContentConfigurator(
+@pytest.fixture(name="content_factory")
+def content_factory_fixture():
+    return ConfigurationFileV2ContentFactory(
         content_builder=ConfigurationTOMLContentBuilder()
     )
 
@@ -134,9 +134,7 @@ def test_reading_argument_attribute_defined_within_specified_profile(
 
 
 def test_saving_configuration(
-    content_configurator: ConfigurationFileContentConfigurator[
-        ConfigurationFileV2Model
-    ],
+    content_factory: ConfigurationFileContentFactory[ConfigurationFileV2Model],
     protostar_toml_content: str,
 ):
     configuration_file_v2_model = ConfigurationFileV2Model(
@@ -162,7 +160,7 @@ def test_saving_configuration(
         profile_name_to_project_config={"release": {"network": "mainnet2"}},
     )
 
-    result = content_configurator.create_file_content(
+    result = content_factory.create_file_content(
         model=configuration_file_v2_model,
     )
 
@@ -194,7 +192,7 @@ def test_transforming_model_v1_into_v2():
 
 def test_transforming_file_v1_into_v2(
     protostar_toml_content: str,
-    content_configurator: ConfigurationFileV2ContentConfigurator,
+    content_factory: ConfigurationFileV2ContentFactory,
 ):
     old_protostar_toml_content = textwrap.dedent(
         """\
@@ -239,7 +237,7 @@ def test_transforming_file_v1_into_v2(
         command_names_provider=CommandNamesProviderStub(),
     ).read()
 
-    transformed_protostar_toml = content_configurator.create_file_content(
+    transformed_protostar_toml = content_factory.create_file_content(
         model=ConfigurationFileV2Model.from_v1(model_v1, protostar_version="9.9.9"),
     )
 
@@ -247,7 +245,7 @@ def test_transforming_file_v1_into_v2(
 
 
 def test_saving_in_particular_order(
-    content_configurator: ConfigurationFileV2ContentConfigurator,
+    content_factory: ConfigurationFileV2ContentFactory,
 ):
 
     configuration_file_v2_model = ConfigurationFileV2Model(
@@ -264,7 +262,7 @@ def test_saving_in_particular_order(
         profile_name_to_project_config={},
     )
 
-    result = content_configurator.create_file_content(
+    result = content_factory.create_file_content(
         model=configuration_file_v2_model,
     )
 

--- a/protostar/configuration_file/configuration_file_v2_test.py
+++ b/protostar/configuration_file/configuration_file_v2_test.py
@@ -26,7 +26,7 @@ from .configuration_file_v2 import (
 from .configuration_legacy_toml_interpreter import ConfigurationLegacyTOMLInterpreter
 
 
-class CommandNamesProviderDouble(CommandNamesProviderProtocol):
+class CommandNamesProviderStub(CommandNamesProviderProtocol):
     def get_command_names(self) -> list[str]:
         return ["declare"]
 
@@ -236,7 +236,7 @@ def test_transforming_file_v1_into_v2(
         ),
         project_root_path=Path(),
         file_path=Path(),
-        command_names_provider=CommandNamesProviderDouble(),
+        command_names_provider=CommandNamesProviderStub(),
     ).read()
 
     transformed_protostar_toml = content_configurator.create_file_content(

--- a/protostar/configuration_file/configuration_file_v2_test.py
+++ b/protostar/configuration_file/configuration_file_v2_test.py
@@ -73,7 +73,7 @@ def configuration_file_fixture(project_root_path: Path, protostar_toml_content: 
     return ConfigurationFileV2(
         project_root_path=project_root_path,
         configuration_file_interpreter=configuration_toml_reader,
-        filename=protostar_toml_path.name,
+        file_path=protostar_toml_path,
     )
 
 
@@ -235,7 +235,7 @@ def test_transforming_file_v1_into_v2(
             file_content=old_protostar_toml_content,
         ),
         project_root_path=Path(),
-        filename="_",
+        file_path=Path(),
         command_names_provider=CommandNamesProviderDouble(),
     ).read()
 

--- a/protostar/configuration_file/configuration_toml_content_builder.py
+++ b/protostar/configuration_file/configuration_toml_content_builder.py
@@ -59,5 +59,5 @@ class ConfigurationTOMLContentBuilder(ConfigurationFileContentBuilder):
         self._doc.add("profile", self._profiles_table)
         return tomlkit.dumps(self._doc)
 
-    def get_file_extension(self) -> str:
+    def get_content_format(self) -> str:
         return "toml"

--- a/protostar/configuration_file/configuration_toml_content_builder.py
+++ b/protostar/configuration_file/configuration_toml_content_builder.py
@@ -58,3 +58,6 @@ class ConfigurationTOMLContentBuilder(ConfigurationFileContentBuilder):
     def build(self) -> str:
         self._doc.add("profile", self._profiles_table)
         return tomlkit.dumps(self._doc)
+
+    def get_file_extension(self) -> str:
+        return "toml"

--- a/protostar/configuration_file/configuration_toml_content_builder_test.py
+++ b/protostar/configuration_file/configuration_toml_content_builder_test.py
@@ -13,7 +13,7 @@ class SimpleConfigurationModel:
     data: dict
 
 
-class ContentConfiguratorDouble(
+class FakeContentConfigurator(
     ConfigurationFileContentConfigurator[SimpleConfigurationModel]
 ):
     def create_file_content(
@@ -30,7 +30,7 @@ class ContentConfiguratorDouble(
 
 
 def test_saving_sections_without_double_quotes():
-    content_configurator = ContentConfiguratorDouble()
+    content_configurator = FakeContentConfigurator()
 
     model = SimpleConfigurationModel(
         profile_name="devnet", section_name="declare", data={"network": "devnet"}

--- a/protostar/configuration_file/configuration_toml_content_builder_test.py
+++ b/protostar/configuration_file/configuration_toml_content_builder_test.py
@@ -2,10 +2,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Union
 
-from .configuration_file import (
-    ConfigurationFileContentBuilder,
-    ConfigurationFileContentConfigurator,
-)
+from .configuration_file import ConfigurationFileContentConfigurator
 from .configuration_toml_content_builder import ConfigurationTOMLContentBuilder
 
 
@@ -21,9 +18,9 @@ class ContentConfiguratorDouble(
 ):
     def create_file_content(
         self,
-        content_builder: ConfigurationFileContentBuilder,
         model: SimpleConfigurationModel,
     ) -> Any:
+        content_builder = ConfigurationTOMLContentBuilder()
         content_builder.set_section(
             profile_name=model.profile_name,
             section_name=model.section_name,
@@ -38,10 +35,8 @@ def test_saving_sections_without_double_quotes():
     model = SimpleConfigurationModel(
         profile_name="devnet", section_name="declare", data={"network": "devnet"}
     )
-    content_builder = ConfigurationTOMLContentBuilder()
 
     result = content_configurator.create_file_content(
-        content_builder=content_builder,
         model=model,
     )
 

--- a/protostar/configuration_file/configuration_toml_content_builder_test.py
+++ b/protostar/configuration_file/configuration_toml_content_builder_test.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Union
 
-from .configuration_file import ConfigurationFileContentConfigurator
+from .configuration_file import ConfigurationFileContentFactory
 from .configuration_toml_content_builder import ConfigurationTOMLContentBuilder
 
 
@@ -13,9 +13,7 @@ class SimpleConfigurationModel:
     data: dict
 
 
-class FakeContentConfigurator(
-    ConfigurationFileContentConfigurator[SimpleConfigurationModel]
-):
+class FakeContentFactory(ConfigurationFileContentFactory[SimpleConfigurationModel]):
     def create_file_content(
         self,
         model: SimpleConfigurationModel,
@@ -30,13 +28,13 @@ class FakeContentConfigurator(
 
 
 def test_saving_sections_without_double_quotes():
-    content_configurator = FakeContentConfigurator()
+    content_factory = FakeContentFactory()
 
     model = SimpleConfigurationModel(
         profile_name="devnet", section_name="declare", data={"network": "devnet"}
     )
 
-    result = content_configurator.create_file_content(
+    result = content_factory.create_file_content(
         model=model,
     )
 

--- a/protostar/configuration_file/conftest.py
+++ b/protostar/configuration_file/conftest.py
@@ -13,7 +13,7 @@ protostar-version = "0.5.0"
 """
 
 
-class CommandNamesProviderTestDouble(CommandNamesProviderProtocol):
+class FakeCommandNamesProvider(CommandNamesProviderProtocol):
     def __init__(self, command_names: list[str]) -> None:
         super().__init__()
         self._command_names = command_names

--- a/protostar/configuration_file/conftest.py
+++ b/protostar/configuration_file/conftest.py
@@ -1,0 +1,22 @@
+from protostar.configuration_file.configuration_file_v1 import (
+    CommandNamesProviderProtocol,
+)
+
+PROTOSTAR_TOML_V1_CONTENT = """
+["protostar.config"]
+protostar_version = "0.4.0"
+"""
+
+PROTOSTAR_TOML_V2_CONTENT = """
+[project]
+protostar-version = "0.5.0"
+"""
+
+
+class CommandNamesProviderTestDouble(CommandNamesProviderProtocol):
+    def __init__(self, command_names: list[str]) -> None:
+        super().__init__()
+        self._command_names = command_names
+
+    def get_command_names(self) -> list[str]:
+        return self._command_names

--- a/protostar/self/__init__.py
+++ b/protostar/self/__init__.py
@@ -1,5 +1,6 @@
 from .protostar_compatibility_with_project_checker import (
     DeclaredProtostarVersionProviderProtocol,
     ProtostarVersion,
+    ProtostarVersionProviderProtocol,
     parse_protostar_version,
 )

--- a/protostar/self/conftest.py
+++ b/protostar/self/conftest.py
@@ -4,7 +4,7 @@ from .protostar_compatibility_with_project_checker import (
 )
 
 
-class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
+class FakeProtostarVersionProvider(ProtostarVersionProviderProtocol):
     def __init__(self, protostar_version_str: str):
         self._protostar_version_str = protostar_version_str
 

--- a/protostar/self/conftest.py
+++ b/protostar/self/conftest.py
@@ -1,0 +1,12 @@
+from .protostar_compatibility_with_project_checker import (
+    ProtostarVersionProviderProtocol,
+    parse_protostar_version,
+)
+
+
+class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
+    def __init__(self, protostar_version_str: str):
+        self._protostar_version_str = protostar_version_str
+
+    def get_protostar_version(self):
+        return parse_protostar_version(self._protostar_version_str)

--- a/protostar/self/protostar_compatibility_with_project_checker_test.py
+++ b/protostar/self/protostar_compatibility_with_project_checker_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from .conftest import ProtostarVersionProviderDouble
 from .protostar_compatibility_with_project_checker import (
     CompatibilityCheckResult,
     DeclaredProtostarVersionProviderProtocol,
@@ -15,14 +16,6 @@ class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProviderPro
 
     def get_declared_protostar_version(self):
         return parse_protostar_version(self._declared_protostar_version_str)
-
-
-class ProtostarVersionProviderDouble(ProtostarVersionProviderProtocol):
-    def __init__(self, protostar_version_str: str):
-        self._protostar_version_str = protostar_version_str
-
-    def get_protostar_version(self):
-        return parse_protostar_version(self._protostar_version_str)
 
 
 @pytest.fixture(name="declared_protostar_version_provider")

--- a/protostar/self/protostar_compatibility_with_project_checker_test.py
+++ b/protostar/self/protostar_compatibility_with_project_checker_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .conftest import ProtostarVersionProviderDouble
+from .conftest import FakeProtostarVersionProvider
 from .protostar_compatibility_with_project_checker import (
     CompatibilityCheckResult,
     DeclaredProtostarVersionProviderProtocol,
@@ -10,7 +10,7 @@ from .protostar_compatibility_with_project_checker import (
 )
 
 
-class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProviderProtocol):
+class FakeDeclaredProtostarVersionProvider(DeclaredProtostarVersionProviderProtocol):
     def __init__(self, declared_protostar_version_str: str):
         self._declared_protostar_version_str = declared_protostar_version_str
 
@@ -20,12 +20,12 @@ class DeclaredProtostarVersionProviderDouble(DeclaredProtostarVersionProviderPro
 
 @pytest.fixture(name="declared_protostar_version_provider")
 def declared_protostar_version_provider_fixture(declared_protostar_version: str):
-    return DeclaredProtostarVersionProviderDouble(declared_protostar_version)
+    return FakeDeclaredProtostarVersionProvider(declared_protostar_version)
 
 
 @pytest.fixture(name="protostar_version_provider")
 def protostar_version_provider_fixture(protostar_version: str):
-    return ProtostarVersionProviderDouble(protostar_version)
+    return FakeProtostarVersionProvider(protostar_version)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds Configuration File Migrator and corresponding command. The command isn't visible to the user yet.