### PR TITLE
Reformat & fix typos in `send_message_to_l2` docs

### DIFF
--- a/website/docs/tutorials/07-testing/02-cheatcodes/send-message-to-l2.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/send-message-to-l2.md
@@ -2,15 +2,15 @@
 
 ```python
 def send_message_to_l2(
-        fn_name: str,
-        from_address: int = 0,
-        to_address: Optional[int] = None,
-        payload: Optional[CairoOrPythonData] = None,
-    ) -> None:
-        ...
+    fn_name: str,
+    from_address: int = 0,
+    to_address: Optional[int] = None,
+    payload: Optional[CairoOrPythonData] = None,
+) -> None:
+    ...
 ```
 
-This cheatcode simulates an incoming message from l1 to l2 executed with `fn_name` at `to_address` contract address.
+This cheatcode simulates an incoming message from L1 to L2 executed with `fn_name` at `to_address` contract address.
 It can be useful when implementing i.e. a token bridge and wanting to test the message consuming behavior.
 This cheatcode requires that the contract at `to_address` address has a `@l1_handler` named `fn_name`.
 
@@ -24,5 +24,5 @@ You can leverage [data transformer](README.md#data-transformer) to pass payload 
 :::
 
 :::warning
-Do not provide `from_address` (needed for all l1 handlers in StarkNet) in the function's `payload` - this is passed automatically using `from_address` parameter. 
+Do not provide `from_address` (needed for all L1 handlers in StarkNet) in the function's `payload` - this is passed automatically using `from_address` parameter. 
 :::


### PR DESCRIPTION
This PR applies minor fixups in `send_message_to_l2` docs:
1. Reformatted cheatcode signature with Black,
2. `l1, l2` → `L1, L2` to match Starknet's spelling.