### PR TITLE
Make `deploy_contract` constructor call errors more user-friendly

### DIFF
--- a/protostar/testing/cheatcodes/deploy_cheatcode.py
+++ b/protostar/testing/cheatcodes/deploy_cheatcode.py
@@ -71,7 +71,11 @@ class DeployCheatcode(Cheatcode):
         contract_class = self.state.get_contract_class(to_bytes(prepared.class_hash))
 
         if not contract_class.abi:
-            raise CheatcodeException(self, "Contract ABI was not found")
+            raise CheatcodeException(
+                self,
+                f"Contract ABI (class_hash: {hex(prepared.class_hash)}) was not found. "
+                "Unable to verify constructor arguments."
+            )
 
         transformer = to_python_transformer(contract_class.abi, "constructor", "inputs")
         try:

--- a/protostar/testing/cheatcodes/deploy_cheatcode.py
+++ b/protostar/testing/cheatcodes/deploy_cheatcode.py
@@ -74,7 +74,7 @@ class DeployCheatcode(Cheatcode):
             raise CheatcodeException(
                 self,
                 f"Contract ABI (class_hash: {hex(prepared.class_hash)}) was not found. "
-                "Unable to verify constructor arguments."
+                "Unable to verify constructor arguments.",
             )
 
         transformer = to_python_transformer(contract_class.abi, "constructor", "inputs")

--- a/protostar/testing/cheatcodes/deploy_cheatcode.py
+++ b/protostar/testing/cheatcodes/deploy_cheatcode.py
@@ -60,7 +60,6 @@ class DeployCheatcode(Cheatcode):
         return DeployedContract(contract_address=prepared.contract_address)
 
     def invoke_constructor(self, prepared: PreparedContract):
-
         self.validate_constructor_args(prepared)
         self.execute_constructor_entry_point(
             class_hash_bytes=to_bytes(prepared.class_hash),

--- a/protostar/testing/cheatcodes/prepare_cheatcode.py
+++ b/protostar/testing/cheatcodes/prepare_cheatcode.py
@@ -11,6 +11,7 @@ from protostar.starknet.data_transformer import (
     CairoOrPythonData,
     PythonData,
     from_python_transformer,
+    DataTransformerException,
 )
 
 from .declare_cheatcode import DeclaredContract
@@ -81,4 +82,10 @@ class PrepareCheatcode(Cheatcode):
             "constructor",
             "inputs",
         )
-        return transformer(constructor_calldata)
+        try:
+            return transformer(constructor_calldata)
+        except DataTransformerException as dt_exc:
+            raise CheatcodeException(
+                self,
+                f"There was an error while parsing constructor arguments:\n{dt_exc.message}",
+            ) from dt_exc

--- a/tests/integration/cheatcodes/deploy_contract/deploy_contract_test.py
+++ b/tests/integration/cheatcodes/deploy_contract/deploy_contract_test.py
@@ -6,13 +6,16 @@ import pytest
 from tests.integration.conftest import (
     RunCairoTestRunnerFixture,
     assert_cairo_test_cases,
+    CreateProtostarProjectFixture,
 )
+
+TEST_CONTRACTS_PATH = Path(__file__).parent
 
 
 @pytest.mark.asyncio
 async def test_deploy_contract(run_cairo_test_runner: RunCairoTestRunnerFixture):
     testing_summary = await run_cairo_test_runner(
-        Path(__file__).parent / "deploy_contract_test.cairo",
+        TEST_CONTRACTS_PATH / "deploy_contract_test.cairo",
         cairo_path=[Path() / "tests" / "integration" / "data"],
     )
 
@@ -39,12 +42,14 @@ async def test_deploy_contract(run_cairo_test_runner: RunCairoTestRunnerFixture)
 
 
 @pytest.mark.asyncio
-def test_deploying_contract_by_name(create_protostar_project):
+def test_deploying_contract_by_name(
+    create_protostar_project: CreateProtostarProjectFixture,
+):
     with create_protostar_project() as protostar:
         protostar.create_files(
             {
-                "./src/main.cairo": Path(__file__).parent / "basic_contract.cairo",
-                "./tests/test_main.cairo": Path(__file__).parent
+                "./src/main.cairo": TEST_CONTRACTS_PATH / "basic_contract.cairo",
+                "./tests/test_main.cairo": TEST_CONTRACTS_PATH
                 / "deploying_contract_by_name_test.cairo",
             }
         )
@@ -53,3 +58,21 @@ def test_deploying_contract_by_name(create_protostar_project):
     assert_cairo_test_cases(
         result, expected_passed_test_cases_names=["test_deploy_contract_by_name"]
     )
+
+
+async def test_contract_deployment_with_incorrect_constructor_args(
+    run_cairo_test_runner: RunCairoTestRunnerFixture,
+):
+    testing_summary = await run_cairo_test_runner(
+        TEST_CONTRACTS_PATH / "deploying_contract_with_incorrect_args_test.cairo",
+    )
+
+    assert {broken.test_case_name for broken in testing_summary.broken} == {
+        "test_deploying_contract_with_incorrect_args",
+        "test_deploying_contract_with_incorrect_arg_types",
+    }
+
+    for broken_case in testing_summary.broken:
+        assert "There was an error while parsing constructor arguments" in str(
+            broken_case.exception
+        )

--- a/tests/integration/cheatcodes/deploy_contract/deploying_contract_with_incorrect_args_test.cairo
+++ b/tests/integration/cheatcodes/deploy_contract/deploying_contract_with_incorrect_args_test.cairo
@@ -1,0 +1,16 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+@external
+func test_deploying_contract_with_incorrect_args{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(){
+     // Should have one constructor arg
+    %{ deploy_contract('./tests/integration/cheatcodes/deploy_contract/basic_with_constructor.cairo') %}
+    return ();
+}
+
+@external
+func test_deploying_contract_with_incorrect_arg_types{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(){
+     // Should have one constructor arg
+    %{ deploy_contract('./tests/integration/cheatcodes/deploy_contract/basic_with_constructor.cairo', constructor_args={"initial_balance": {"low": 1, "high": 0}}) %}
+    return ();
+}


### PR DESCRIPTION
This PR adds some parsing of the arguments and catching the exceptions, in order to produce more user-friendly way of reporting constructor argument errors.

fixes #912