### PR TITLE
Do not lit a fire so much in some cheatcodes docs

### DIFF
--- a/website/docs/tutorials/07-testing/02-cheatcodes/example.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/example.md
@@ -12,10 +12,11 @@ In such a case, they are run sequentially.
 In such a case, first all the `example`s are run and only then the the data from `given` is applied.
 Otherwise, only the data from `example`s is applied.
 
-:::warning
+:::info
 This cheatcode is only available in [setup cases](../README.md#setup-case).
 :::
-:::warning
+
+:::info
 `example` is not limited by [`max_examples`](./max-examples.md) and is not connected to it in any way.
 :::
 

--- a/website/docs/tutorials/07-testing/02-cheatcodes/given.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/given.md
@@ -9,7 +9,7 @@ The built-in strategies are provided by the [`strategy`](./strategy.md) cheatcod
 and for a list of available strategies, see the [fuzzing strategies](../03-fuzzing/strategies.md)
 guide page.
 
-:::warning
+:::info
 This cheatcode is only available in [setup cases](../README.md#setup-case).
 :::
 

--- a/website/docs/tutorials/07-testing/02-cheatcodes/max-examples.md
+++ b/website/docs/tutorials/07-testing/02-cheatcodes/max-examples.md
@@ -10,7 +10,7 @@ Fuzzer tries at most this many input examples. If it does not find any failing, 
 `max_examples` does not limit the examples specified by [`example`](./example.md) cheatcode.
 It only affects the [`given`](./given.md) cheatcode and any examples added with `example` will be applied additionally.
 
-:::warning
+:::info
 This cheatcode is only available in [setup hooks](../README.md#setup-hooks).
 :::
 


### PR DESCRIPTION
I find these warning boxes to be misleading, as there is no danger here. We only want users to pay attention.