### PR TITLE
Hot-fix stale comments

### DIFF
--- a/website/src/theme/DocPage/Layout/Main/index.js
+++ b/website/src/theme/DocPage/Layout/Main/index.js
@@ -3,10 +3,12 @@ import Main from '@theme-original/DocPage/Layout/Main'
 import Giscus from '@giscus/react'
 import { useColorMode } from '@docusaurus/theme-common'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import { useLocation } from 'react-router-dom'
 
 export default function MainWrapper({ children, ...props }) {
   const { isDarkTheme } = useColorMode()
   const { siteConfig } = useDocusaurusContext()
+  const location = useLocation()
 
   return (
     <Main {...props}>
@@ -14,6 +16,7 @@ export default function MainWrapper({ children, ...props }) {
       <div className='row margin-top--md'>
         <div className='col'>
           <Giscus
+            key={location.pathname}
             repo='software-mansion/protostar'
             repoId='R_kgDOGw_HxA'
             categoryId='DIC_kwDOGw_HxM4CSDJD'

--- a/website/src/theme/DocPage/Layout/Main/index.js
+++ b/website/src/theme/DocPage/Layout/Main/index.js
@@ -21,14 +21,14 @@ export default function MainWrapper({ children, ...props }) {
             repoId='R_kgDOGw_HxA'
             categoryId='DIC_kwDOGw_HxM4CSDJD'
             category='Documentation'
-            mapping='url'
+            mapping='pathname'
             reactionsEnabled='0'
             emitMetadata='0'
             inputPosition='top'
             theme={isDarkTheme ? 'dark' : 'light'}
             lang={siteConfig.i18n.defaultLocale}
             loading='lazy'
-            strict={true}
+            strict
           />
         </div>
         <div className='col col--3' />


### PR DESCRIPTION
Fix stale comment box after navigating to a different page and change the mapping method to `pathname` (`title` mapping didn't work and `url` was too verbose).