### PR TITLE
Redesigning `protostar.toml` 13 — Rolling integration — Package management commands

### DIFF
--- a/protostar/cli/__init__.py
+++ b/protostar/cli/__init__.py
@@ -1,5 +1,5 @@
 from .activity_indicator import ActivityIndicator
-from .common_arguments import lib_path_arg
+from .common_arguments import LIB_PATH_ARG
 from .lib_path_resolver import LibPathResolver
 from .network_command_util import NetworkCommandUtil
 from .protostar_arg_type import map_protostar_type_name_to_parser

--- a/protostar/cli/__init__.py
+++ b/protostar/cli/__init__.py
@@ -1,4 +1,6 @@
 from .activity_indicator import ActivityIndicator
+from .common_arguments import lib_path_arg
+from .lib_path_resolver import LibPathResolver
 from .network_command_util import NetworkCommandUtil
 from .protostar_arg_type import map_protostar_type_name_to_parser
 from .protostar_argument import ProtostarArgument

--- a/protostar/cli/common_arguments.py
+++ b/protostar/cli/common_arguments.py
@@ -2,6 +2,7 @@ from .protostar_argument import ProtostarArgument
 
 lib_path_arg = ProtostarArgument(
     name="lib-path",
-    description="Directory containing project dependencies",
+    description="Directory containing project dependencies. "
+    "This argument is/will after migrating the configuration file.",
     type="path",
 )

--- a/protostar/cli/common_arguments.py
+++ b/protostar/cli/common_arguments.py
@@ -3,6 +3,6 @@ from .protostar_argument import ProtostarArgument
 LIB_PATH_ARG = ProtostarArgument(
     name="lib-path",
     description="Directory containing project dependencies. "
-    "This argument is/will after migrating the configuration file.",
+    "This argument is used with the configuration file V2.",
     type="path",
 )

--- a/protostar/cli/common_arguments.py
+++ b/protostar/cli/common_arguments.py
@@ -1,6 +1,6 @@
 from .protostar_argument import ProtostarArgument
 
-lib_path_arg = ProtostarArgument(
+LIB_PATH_ARG = ProtostarArgument(
     name="lib-path",
     description="Directory containing project dependencies. "
     "This argument is/will after migrating the configuration file.",

--- a/protostar/cli/common_arguments.py
+++ b/protostar/cli/common_arguments.py
@@ -1,0 +1,8 @@
+from .protostar_argument import ProtostarArgument
+
+lib_path_arg = ProtostarArgument(
+    name="lib-path",
+    description="Directory containing project dependencies",
+    type="path",
+    default="lib",
+)

--- a/protostar/cli/common_arguments.py
+++ b/protostar/cli/common_arguments.py
@@ -4,5 +4,4 @@ lib_path_arg = ProtostarArgument(
     name="lib-path",
     description="Directory containing project dependencies",
     type="path",
-    default="lib",
 )

--- a/protostar/cli/lib_path_resolver.py
+++ b/protostar/cli/lib_path_resolver.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from typing import Optional
+
+from protostar.configuration_file import ConfigurationFile
+
+
+class LibPathResolver:
+    """
+    This class resolves a path to the library directory uniformly for `ConfigurationFileV1` and `ConfigurationFileV2`.
+    The lib-path was always configured in the CFV1 whereas CFV2 expects lib-path to be a command specific argument.
+    """
+
+    def __init__(
+        self,
+        project_root_path: Path,
+        configuration_file: ConfigurationFile,
+        legacy_mode: bool = False,
+    ):
+        self._project_root_path = project_root_path
+        self._configuration_file = configuration_file
+        self._legacy_mode = legacy_mode
+
+    def resolve(self, lib_path_provided_as_arg: Optional[Path]):
+        if self._legacy_mode:
+            return (
+                self._configuration_file.get_lib_path()
+                or self._project_root_path / "lib"
+            )
+        return self._project_root_path / (lib_path_provided_as_arg or "lib")

--- a/protostar/cli/lib_path_resolver.py
+++ b/protostar/cli/lib_path_resolver.py
@@ -1,4 +1,4 @@
-from logging import Logger
+from logging import getLogger
 from pathlib import Path
 from typing import Optional
 
@@ -17,20 +17,19 @@ class LibPathResolver:
         self,
         project_root_path: Path,
         configuration_file: ConfigurationFile,
-        logger: Logger,
         legacy_mode: bool,
     ):
         self._project_root_path = project_root_path
         self._configuration_file = configuration_file
-        self._logger = logger
         self._legacy_mode = legacy_mode
 
     def resolve(self, lib_path_provided_as_arg: Optional[Path]) -> Path:
         if self._legacy_mode:
             if lib_path_provided_as_arg:
-                self._logger.warning(
-                    f"Argument '{lib_path_arg.name}' is ignored. "
-                    "Please migrate your configuration file if the command `migrate-configuration-file` is available."
+                getLogger().warning(
+                    "Argument %s is ignored. "
+                    "Please migrate your configuration file if the command `migrate-configuration-file` is available.",
+                    lib_path_arg.name,
                 )
             return (
                 self._configuration_file.get_lib_path()

--- a/protostar/cli/lib_path_resolver.py
+++ b/protostar/cli/lib_path_resolver.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from protostar.configuration_file import ConfigurationFile
 
-from .common_arguments import lib_path_arg
+from .common_arguments import LIB_PATH_ARG
 
 
 class LibPathResolver:
@@ -29,7 +29,7 @@ class LibPathResolver:
                 getLogger().warning(
                     "Argument %s is ignored. "
                     "Please migrate your configuration file if the command `migrate-configuration-file` is available.",
-                    lib_path_arg.name,
+                    LIB_PATH_ARG.name,
                 )
             return (
                 self._configuration_file.get_lib_path()

--- a/protostar/cli/lib_path_resolver.py
+++ b/protostar/cli/lib_path_resolver.py
@@ -1,7 +1,10 @@
+from logging import Logger
 from pathlib import Path
 from typing import Optional
 
 from protostar.configuration_file import ConfigurationFile
+
+from .common_arguments import lib_path_arg
 
 
 class LibPathResolver:
@@ -14,14 +17,21 @@ class LibPathResolver:
         self,
         project_root_path: Path,
         configuration_file: ConfigurationFile,
-        legacy_mode: bool = False,
+        logger: Logger,
+        legacy_mode: bool,
     ):
         self._project_root_path = project_root_path
         self._configuration_file = configuration_file
+        self._logger = logger
         self._legacy_mode = legacy_mode
 
-    def resolve(self, lib_path_provided_as_arg: Optional[Path]):
+    def resolve(self, lib_path_provided_as_arg: Optional[Path]) -> Path:
         if self._legacy_mode:
+            if lib_path_provided_as_arg:
+                self._logger.warning(
+                    f"Argument '{lib_path_arg.name}' is ignored. "
+                    "Please migrate your configuration file if the command `migrate-configuration-file` is available."
+                )
             return (
                 self._configuration_file.get_lib_path()
                 or self._project_root_path / "lib"

--- a/protostar/cli/lib_path_resolver_test.py
+++ b/protostar/cli/lib_path_resolver_test.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from protostar.configuration_file import FakeConfigurationFile
+
+from .lib_path_resolver import LibPathResolver
+
+
+def test_happy_case_in_legacy_mode(tmp_path: Path):
+    resolver = LibPathResolver(
+        project_root_path=tmp_path,
+        configuration_file=FakeConfigurationFile(lib_path=tmp_path / "deps"),
+        legacy_mode=True,
+    )
+
+    result = resolver.resolve(lib_path_provided_as_arg=None)
+
+    assert result == tmp_path / "deps"
+
+
+def test_default_value_in_legacy_mode(tmp_path: Path):
+    resolver = LibPathResolver(
+        project_root_path=tmp_path,
+        configuration_file=FakeConfigurationFile(lib_path=None),
+        legacy_mode=True,
+    )
+
+    result = resolver.resolve(lib_path_provided_as_arg=None)
+
+    assert result == tmp_path / "lib"
+
+
+def test_arg_is_provided_in_legacy_mode(
+    tmp_path: Path,
+):
+    resolver = LibPathResolver(
+        project_root_path=tmp_path,
+        configuration_file=FakeConfigurationFile(lib_path=tmp_path / "deps"),
+        legacy_mode=True,
+    )
+
+    result = resolver.resolve(lib_path_provided_as_arg=Path("deps2"))
+
+    assert result == tmp_path / "deps"
+
+
+def test_happy_case_when_legacy_mode_is_off(tmp_path: Path):
+    resolver = LibPathResolver(
+        project_root_path=tmp_path,
+        configuration_file=FakeConfigurationFile(lib_path=tmp_path / "deps"),
+        legacy_mode=False,
+    )
+
+    result = resolver.resolve(lib_path_provided_as_arg=Path("deps2"))
+
+    assert result == tmp_path / "deps2"
+
+
+def test_default_value_when_legacy_mode_is_off(tmp_path: Path):
+    resolver = LibPathResolver(
+        project_root_path=tmp_path,
+        configuration_file=FakeConfigurationFile(lib_path=tmp_path / "deps"),
+        legacy_mode=False,
+    )
+
+    result = resolver.resolve(lib_path_provided_as_arg=None)
+
+    assert result == tmp_path / "lib"

--- a/protostar/commands/install/install_command.py
+++ b/protostar/commands/install/install_command.py
@@ -109,6 +109,12 @@ class InstallCommand(ProtostarCommand):
                 ConfigurationFile.create_appending_cairo_path_suggestion()
             )
         else:
+            if not libs_path.exists():
+                self._logger.warning(
+                    f"Directory {libs_path} doesn't exist.\n"
+                    "Did you install any package before running this command?"
+                )
+                return
             pull_package_submodules(
                 on_submodule_update_start=lambda package_info: self._logger.info(
                     "Installing %s%s%s %s(%s)%s",

--- a/protostar/commands/install/install_command.py
+++ b/protostar/commands/install/install_command.py
@@ -4,13 +4,12 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from protostar.cli import ProtostarArgument, ProtostarCommand
-from protostar.commands.install.install_package_from_repo import (
-    install_package_from_repo,
-)
-from protostar.commands.install.pull_package_submodules import pull_package_submodules
+from protostar.configuration_file import ConfigurationFile
 from protostar.io.log_color_provider import LogColorProvider
 from protostar.package_manager import extract_info_from_repo_id
-from protostar.protostar_toml.protostar_project_section import ProtostarProjectSection
+
+from .install_package_from_repo import install_package_from_repo
+from .pull_package_submodules import pull_package_submodules
 
 EXTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION = """- `GITHUB_ACCOUNT_NAME/REPO_NAME[@TAG]`
     - `OpenZeppelin/cairo-contracts@v0.4.0`
@@ -25,13 +24,13 @@ class InstallCommand(ProtostarCommand):
     def __init__(
         self,
         project_root_path: Path,
-        project_section_loader: ProtostarProjectSection.Loader,
+        configuration_file: ConfigurationFile,
         logger: Logger,
         log_color_provider: LogColorProvider,
     ) -> None:
         super().__init__()
         self._project_root_path = project_root_path
-        self._project_section_loader = project_section_loader
+        self._configuration_file = configuration_file
         self._logger = logger
         self._log_color_provider = log_color_provider
 
@@ -87,8 +86,9 @@ class InstallCommand(ProtostarCommand):
         on_unknown_version: Callable,
         alias: Optional[str] = None,
     ) -> None:
-        project_section = self._project_section_loader.load()
-        libs_path = self._project_root_path / project_section.libs_relative_path
+        libs_path = (
+            self._configuration_file.get_lib_path() or self._project_root_path / "lib"
+        )
 
         if package_name:
             package_info = extract_info_from_repo_id(package_name)

--- a/protostar/commands/install/install_command.py
+++ b/protostar/commands/install/install_command.py
@@ -7,7 +7,7 @@ from protostar.cli import (
     LibPathResolver,
     ProtostarArgument,
     ProtostarCommand,
-    lib_path_arg,
+    LIB_PATH_ARG,
 )
 from protostar.configuration_file import ConfigurationFile
 from protostar.io.log_color_provider import LogColorProvider
@@ -54,7 +54,7 @@ class InstallCommand(ProtostarCommand):
     @property
     def arguments(self):
         return [
-            lib_path_arg,
+            LIB_PATH_ARG,
             ProtostarArgument(
                 name="package",
                 description=EXTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,

--- a/protostar/commands/remove/remove_command.py
+++ b/protostar/commands/remove/remove_command.py
@@ -8,6 +8,7 @@ from protostar.commands.install.install_command import (
     EXTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,
 )
 from protostar.commands.remove.remove_package import remove_package
+from protostar.configuration_file import ConfigurationFile
 from protostar.io import log_color_provider
 from protostar.package_manager import retrieve_real_package_name
 from protostar.protostar_toml.protostar_project_section import ProtostarProjectSection
@@ -23,12 +24,12 @@ class RemoveCommand(ProtostarCommand):
     def __init__(
         self,
         project_root_path: Path,
-        project_section_loader: ProtostarProjectSection.Loader,
+        configuration_file: ConfigurationFile,
         logger: Logger,
     ) -> None:
         super().__init__()
         self._project_root_path = project_root_path
-        self._project_section_loader = project_section_loader
+        self._configuration_file = configuration_file
         self._logger = logger
 
     @property
@@ -65,12 +66,12 @@ class RemoveCommand(ProtostarCommand):
         self._logger.info("Removed the package successfully")
 
     def remove(self, internal_dependency_reference: str):
-        project_section = self._project_section_loader.load()
+        lib_path = self._configuration_file.get_lib_path()
 
         package_name = retrieve_real_package_name(
             internal_dependency_reference,
             self._project_root_path,
-            project_section.libs_relative_path,
+            lib_path.relative_to(self._project_root_path) if lib_path else Path("lib"),
         )
 
         self._logger.info(

--- a/protostar/commands/remove/remove_command.py
+++ b/protostar/commands/remove/remove_command.py
@@ -11,7 +11,6 @@ from protostar.commands.remove.remove_package import remove_package
 from protostar.configuration_file import ConfigurationFile
 from protostar.io import log_color_provider
 from protostar.package_manager import retrieve_real_package_name
-from protostar.protostar_toml.protostar_project_section import ProtostarProjectSection
 
 INTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION = (
     EXTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION

--- a/protostar/commands/remove/remove_command.py
+++ b/protostar/commands/remove/remove_command.py
@@ -72,6 +72,12 @@ class RemoveCommand(ProtostarCommand):
         self._logger.info("Removed the package successfully")
 
     def remove(self, internal_dependency_reference: str, lib_path: Path):
+        if not lib_path.exists():
+            self._logger.warning(
+                f"Directory {lib_path} doesn't exist.\n"
+                "Did you install any package before running this command?"
+            )
+            return
         package_name = retrieve_real_package_name(
             internal_dependency_reference,
             self._project_root_path,

--- a/protostar/commands/remove/remove_command.py
+++ b/protostar/commands/remove/remove_command.py
@@ -7,7 +7,7 @@ from protostar.cli import (
     LibPathResolver,
     ProtostarArgument,
     ProtostarCommand,
-    lib_path_arg,
+    LIB_PATH_ARG,
 )
 from protostar.commands.install.install_command import (
     EXTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,
@@ -50,7 +50,7 @@ class RemoveCommand(ProtostarCommand):
     @property
     def arguments(self):
         return [
-            lib_path_arg,
+            LIB_PATH_ARG,
             ProtostarArgument(
                 name="package",
                 description=INTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,

--- a/protostar/commands/remove/remove_command.py
+++ b/protostar/commands/remove/remove_command.py
@@ -3,7 +3,12 @@ from logging import Logger
 from pathlib import Path
 from typing import Optional
 
-from protostar.cli import LibPathResolver, ProtostarArgument, ProtostarCommand
+from protostar.cli import (
+    LibPathResolver,
+    ProtostarArgument,
+    ProtostarCommand,
+    lib_path_arg,
+)
 from protostar.commands.install.install_command import (
     EXTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,
 )
@@ -45,6 +50,7 @@ class RemoveCommand(ProtostarCommand):
     @property
     def arguments(self):
         return [
+            lib_path_arg,
             ProtostarArgument(
                 name="package",
                 description=INTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,
@@ -69,7 +75,7 @@ class RemoveCommand(ProtostarCommand):
         package_name = retrieve_real_package_name(
             internal_dependency_reference,
             self._project_root_path,
-            lib_path.relative_to(self._project_root_path) if lib_path else Path("lib"),
+            packages_dir=lib_path,
         )
         self._logger.info(
             "Removing %s%s%s",

--- a/protostar/commands/update/update_command.py
+++ b/protostar/commands/update/update_command.py
@@ -75,6 +75,13 @@ class UpdateCommand(ProtostarCommand):
         self._logger.info("Updated successfully")
 
     def update(self, package: Optional[str], lib_path: Path) -> None:
+        if not lib_path.exists():
+            self._logger.warning(
+                f"Directory {lib_path} doesn't exist.\n"
+                "Did you install any package before running this command?"
+            )
+            return
+
         if package:
             package = retrieve_real_package_name(
                 package, self._project_root_path, packages_dir=lib_path

--- a/protostar/commands/update/update_command.py
+++ b/protostar/commands/update/update_command.py
@@ -8,7 +8,7 @@ from protostar.cli import (
     LibPathResolver,
     ProtostarArgument,
     ProtostarCommand,
-    lib_path_arg,
+    LIB_PATH_ARG,
 )
 from protostar.commands.remove.remove_command import (
     INTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,
@@ -54,7 +54,7 @@ class UpdateCommand(ProtostarCommand):
     @property
     def arguments(self):
         return [
-            lib_path_arg,
+            LIB_PATH_ARG,
             ProtostarArgument(
                 description=INTERNAL_DEPENDENCY_REFERENCE_DESCRIPTION,
                 name="package",

--- a/protostar/compiler/project_cairo_path_builder.py
+++ b/protostar/compiler/project_cairo_path_builder.py
@@ -31,7 +31,7 @@ class ProjectCairoPathBuilder:
 
     def _build_packages_cairo_path_list(self) -> list[Path]:
         libs_path = self._configuration_file.get_lib_path()
-        if libs_path is None:
+        if libs_path is None or not libs_path.exists():
             return []
         assert libs_path.is_dir(), f"{libs_path} is not a directory"
         (root, dirs, _) = next(os.walk(str(libs_path.resolve())))

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -136,9 +136,7 @@ def build_di_container(
         UpdateCommand(
             logger=logger,
             project_root_path=project_root_path,
-            project_section_loader=ProtostarProjectSection.Loader(
-                protostar_toml_reader
-            ),
+            configuration_file=configuration_file,
         ),
         UpgradeCommand(
             UpgradeManager(

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -106,7 +106,6 @@ def build_di_container(
 
     lib_path_resolver = LibPathResolver(
         configuration_file=configuration_file,
-        logger=logger,
         project_root_path=project_root_path,
         legacy_mode=isinstance(configuration_file, ConfigurationFileV1),
     )

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -7,6 +7,7 @@ from protostar.argument_parser import ArgumentParserFacade
 from protostar.cli import ProtostarCommand, map_protostar_type_name_to_parser
 from protostar.commands import (
     BuildCommand,
+    CallCommand,
     DeclareCommand,
     DeployCommand,
     FormatCommand,
@@ -18,7 +19,6 @@ from protostar.commands import (
     TestCommand,
     UpdateCommand,
     UpgradeCommand,
-    CallCommand,
 )
 from protostar.commands.cairo_migrate_command import CairoMigrateCommand
 from protostar.commands.init.project_creator import (
@@ -126,9 +126,7 @@ def build_di_container(
             log_color_provider=log_color_provider,
             logger=logger,
             project_root_path=project_root_path,
-            project_section_loader=ProtostarProjectSection.Loader(
-                protostar_toml_reader
-            ),
+            configuration_file=configuration_file,
         ),
         RemoveCommand(
             logger=logger,
@@ -181,7 +179,10 @@ def build_di_container(
         ),
         FormatCommand(project_root_path, logger),
         CairoMigrateCommand(script_root, logger),
-        InvokeCommand(gateway_facade_factory=gateway_facade_factory, logger=logger),
+        InvokeCommand(
+            gateway_facade_factory=gateway_facade_factory,
+            logger=logger,
+        ),
         CallCommand(gateway_facade_factory=gateway_facade_factory, logger=logger),
     ]
 

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from protostar.argument_parser import ArgumentParserFacade
 from protostar.cli import ProtostarCommand, map_protostar_type_name_to_parser
+from protostar.cli.lib_path_resolver import LibPathResolver
 from protostar.commands import (
     BuildCommand,
     CallCommand,
@@ -28,6 +29,7 @@ from protostar.commands.init.project_creator import (
 from protostar.compiler import ProjectCairoPathBuilder, ProjectCompiler
 from protostar.compiler.compiled_contract_reader import CompiledContractReader
 from protostar.configuration_file import ConfigurationFileFactory
+from protostar.configuration_file.configuration_file_v1 import ConfigurationFileV1
 from protostar.io import InputRequester, log_color_provider
 from protostar.migrator import Migrator, MigratorExecutionEnvironment
 from protostar.protostar_cli import ProtostarCLI
@@ -102,6 +104,13 @@ def build_di_container(
         compiled_contract_reader=CompiledContractReader(),
     )
 
+    lib_path_resolver = LibPathResolver(
+        configuration_file=configuration_file,
+        logger=logger,
+        project_root_path=project_root_path,
+        legacy_mode=isinstance(configuration_file, ConfigurationFileV1),
+    )
+
     commands: list[ProtostarCommand] = [
         InitCommand(
             requester=requester,
@@ -123,17 +132,17 @@ def build_di_container(
             log_color_provider=log_color_provider,
             logger=logger,
             project_root_path=project_root_path,
-            configuration_file=configuration_file,
+            lib_path_resolver=lib_path_resolver,
         ),
         RemoveCommand(
             logger=logger,
             project_root_path=project_root_path,
-            configuration_file=configuration_file,
+            lib_path_resolver=lib_path_resolver,
         ),
         UpdateCommand(
             logger=logger,
             project_root_path=project_root_path,
-            configuration_file=configuration_file,
+            lib_path_resolver=lib_path_resolver,
         ),
         UpgradeCommand(
             UpgradeManager(

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -131,9 +131,7 @@ def build_di_container(
         RemoveCommand(
             logger=logger,
             project_root_path=project_root_path,
-            project_section_loader=ProtostarProjectSection.Loader(
-                protostar_toml_reader
-            ),
+            configuration_file=configuration_file,
         ),
         UpdateCommand(
             logger=logger,

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -172,10 +172,7 @@ def build_di_container(
         ),
         FormatCommand(project_root_path, logger),
         CairoMigrateCommand(script_root, logger),
-        InvokeCommand(
-            gateway_facade_factory=gateway_facade_factory,
-            logger=logger,
-        ),
+        InvokeCommand(gateway_facade_factory=gateway_facade_factory, logger=logger),
         CallCommand(gateway_facade_factory=gateway_facade_factory, logger=logger),
     ]
 

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -32,8 +32,6 @@ from protostar.io import InputRequester, log_color_provider
 from protostar.migrator import Migrator, MigratorExecutionEnvironment
 from protostar.protostar_cli import ProtostarCLI
 from protostar.protostar_toml import (
-    ProtostarProjectSection,
-    ProtostarTOMLReader,
     ProtostarTOMLWriter,
     search_upwards_protostar_toml_path,
 )
@@ -74,7 +72,6 @@ def build_di_container(
     protostar_directory = ProtostarDirectory(script_root)
     version_manager = VersionManager(protostar_directory, logger)
     protostar_toml_writer = ProtostarTOMLWriter()
-    protostar_toml_reader = ProtostarTOMLReader(protostar_toml_path=protostar_toml_path)
     requester = InputRequester(log_color_provider)
     latest_version_checker = LatestVersionChecker(
         protostar_directory=protostar_directory,

--- a/tests/integration/protostar_fixture.py
+++ b/tests/integration/protostar_fixture.py
@@ -14,12 +14,12 @@ from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
 from protostar.cli.map_targets_to_file_paths import map_targets_to_file_paths
 from protostar.commands import (
     BuildCommand,
-    CallCommand,
     DeclareCommand,
     FormatCommand,
     InitCommand,
     InvokeCommand,
     MigrateCommand,
+    CallCommand,
 )
 from protostar.commands.deploy_command import DeployCommand
 from protostar.commands.init.project_creator.new_project_creator import (

--- a/tests/integration/protostar_fixture.py
+++ b/tests/integration/protostar_fixture.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from argparse import Namespace
 from logging import Logger, getLogger
 from pathlib import Path
@@ -15,12 +14,12 @@ from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
 from protostar.cli.map_targets_to_file_paths import map_targets_to_file_paths
 from protostar.commands import (
     BuildCommand,
+    CallCommand,
     DeclareCommand,
     FormatCommand,
     InitCommand,
     InvokeCommand,
     MigrateCommand,
-    CallCommand,
 )
 from protostar.commands.deploy_command import DeployCommand
 from protostar.commands.init.project_creator.new_project_creator import (

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -158,6 +158,8 @@ Install a dependency as a git submodule.
 - `SSH_URI`
     - `git@github.com:OpenZeppelin/cairo-contracts.git`
 
+#### `--lib-path PATH`
+Directory containing project dependencies. This argument is/will after migrating the configuration file.
 #### `--name STRING`
 A custom package name. Use it to resolve name conflicts.
 ### `invoke`
@@ -244,6 +246,8 @@ Required.
     - `git@github.com:OpenZeppelin/cairo-contracts.git`
 - `PACKAGE_DIRECTORY_NAME`
     - `cairo_contracts`, if the package location is `lib/cairo_contracts`
+#### `--lib-path PATH`
+Directory containing project dependencies. This argument is/will after migrating the configuration file.
 ### `test`
 ```shell
 $ protostar test
@@ -287,6 +291,8 @@ Update a dependency or dependencies. If the default branch of a dependency's rep
     - `git@github.com:OpenZeppelin/cairo-contracts.git`
 - `PACKAGE_DIRECTORY_NAME`
     - `cairo_contracts`, if the package location is `lib/cairo_contracts`
+#### `--lib-path PATH`
+Directory containing project dependencies. This argument is/will after migrating the configuration file.
 ### `upgrade`
 ```shell
 $ protostar upgrade

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -159,7 +159,7 @@ Install a dependency as a git submodule.
     - `git@github.com:OpenZeppelin/cairo-contracts.git`
 
 #### `--lib-path PATH`
-Directory containing project dependencies. This argument is/will after migrating the configuration file.
+Directory containing project dependencies. This argument is used with the configuration file V2.
 #### `--name STRING`
 A custom package name. Use it to resolve name conflicts.
 ### `invoke`
@@ -247,7 +247,7 @@ Required.
 - `PACKAGE_DIRECTORY_NAME`
     - `cairo_contracts`, if the package location is `lib/cairo_contracts`
 #### `--lib-path PATH`
-Directory containing project dependencies. This argument is/will after migrating the configuration file.
+Directory containing project dependencies. This argument is used with the configuration file V2.
 ### `test`
 ```shell
 $ protostar test
@@ -292,7 +292,7 @@ Update a dependency or dependencies. If the default branch of a dependency's rep
 - `PACKAGE_DIRECTORY_NAME`
     - `cairo_contracts`, if the package location is `lib/cairo_contracts`
 #### `--lib-path PATH`
-Directory containing project dependencies. This argument is/will after migrating the configuration file.
+Directory containing project dependencies. This argument is used with the configuration file V2.
 ### `upgrade`
 ```shell
 $ protostar upgrade


### PR DESCRIPTION
Add `lib-path` argument to package management commands. This argument is used after migrating to the `ConfigurationFileV2`. Make lib directory optional.

Related #477 