### PR TITLE
Make all cheatcodes use one shared `internal_calls`. Fix `send_message_to_l2` cheatcode.

### DIFF
--- a/protostar/migrator/migrator_cheatcodes_factory.py
+++ b/protostar/migrator/migrator_cheatcodes_factory.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from starknet_py.net.signer import BaseSigner
-from starkware.starknet.business_logic.execution.objects import CallInfo
 
 from protostar.migrator.cheatcodes.migrator_call_cheatcode import MigratorCallCheatcode
 from protostar.migrator.cheatcodes.migrator_declare_cheatcode import (
@@ -16,9 +15,9 @@ from protostar.migrator.cheatcodes.migrator_invoke_cheatcode import (
 )
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.starknet.cheatcode_factory import CheatcodeFactory
+from protostar.starknet.compiler.starknet_compilation import StarknetCompiler
 from protostar.starknet.hint_local import HintLocal
 from protostar.starknet_gateway.gateway_facade import GatewayFacade
-from protostar.starknet.compiler.starknet_compilation import StarknetCompiler
 
 from .migrator_contract_identifier_resolver import MigratorContractIdentifierResolver
 
@@ -49,7 +48,6 @@ class MigratorCheatcodeFactory(CheatcodeFactory):
     def build_cheatcodes(
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
     ) -> List[Cheatcode]:
         assert self._starknet_compiler is not None
         assert self._config is not None

--- a/protostar/starknet/cheatable_execute_entry_point.py
+++ b/protostar/starknet/cheatable_execute_entry_point.py
@@ -1,12 +1,13 @@
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Tuple, cast, List
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, cast
 
 from starkware.cairo.common.cairo_function_runner import CairoFunctionRunner
 from starkware.cairo.lang.compiler.debug_info import DebugInfo
 from starkware.cairo.lang.compiler.program import Program
 from starkware.cairo.lang.vm.memory_dict import MemoryDict
+from starkware.cairo.lang.vm.memory_segments import FIRST_MEMORY_ADDR as PROGRAM_BASE
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.cairo.lang.vm.security import SecurityError
 from starkware.cairo.lang.vm.trace_entry import TraceEntry
@@ -16,6 +17,7 @@ from starkware.cairo.lang.vm.vm_exceptions import (
     VmException,
     VmExceptionBase,
 )
+from starkware.python.utils import from_bytes
 from starkware.starknet.business_logic.execution.execute_entry_point import (
     ExecuteEntryPoint,
 )
@@ -23,40 +25,35 @@ from starkware.starknet.business_logic.execution.objects import (
     TransactionExecutionContext,
 )
 from starkware.starknet.business_logic.fact_state.state import ExecutionResourcesManager
+from starkware.starknet.business_logic.state.state import StateSyncifier
 from starkware.starknet.business_logic.state.state_api import SyncState
 from starkware.starknet.business_logic.utils import validate_contract_deployed
 from starkware.starknet.core.os import os_utils, syscall_utils
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from starkware.starknet.definitions.general_config import StarknetGeneralConfig
 from starkware.starknet.public import abi as starknet_abi
+from starkware.starknet.services.api.contract_class import (
+    ContractClass,
+    ContractEntryPoint,
+)
 from starkware.starkware_utils.error_handling import (
     StarkException,
     wrap_with_stark_exception,
 )
-from starkware.cairo.lang.vm.memory_segments import FIRST_MEMORY_ADDR as PROGRAM_BASE
-from starkware.starknet.services.api.contract_class import (
-    ContractEntryPoint,
-    ContractClass,
-)
-from starkware.python.utils import from_bytes
-from starkware.starknet.business_logic.state.state import StateSyncifier
-from protostar.profiler.pprof import serialize, to_protobuf
+
 from protostar.profiler.contract_profiler import (
     RuntimeProfile,
     TracerDataManager,
     build_profile,
 )
-from protostar.profiler.transaction_profiler import (
-    merge_profiles,
-)
+from protostar.profiler.pprof import serialize, to_protobuf
+from protostar.profiler.transaction_profiler import merge_profiles
 from protostar.starknet.cheatable_cached_state import CheatableCachedState
-
 from protostar.starknet.cheatable_cairo_function_runner import (
     CheatableCairoFunctionRunner,
 )
 from protostar.starknet.cheatable_syscall_handler import CheatableSysCallHandler
 from protostar.starknet.cheatcode import Cheatcode
-
 
 if TYPE_CHECKING:
     from protostar.starknet.cheatcode_factory import CheatcodeFactory
@@ -133,7 +130,8 @@ class CheatableExecuteEntryPoint(ExecuteEntryPoint):
         )
 
         # region Modified Starknet code.
-        syscall_dependencies = Cheatcode.SyscallDependencies(
+
+        syscall_handler = CheatableSysCallHandler(
             execute_entry_point_cls=CheatableExecuteEntryPoint,
             tx_execution_context=tx_execution_context,
             state=state,
@@ -144,8 +142,6 @@ class CheatableExecuteEntryPoint(ExecuteEntryPoint):
             initial_syscall_ptr=initial_syscall_ptr,
         )
 
-        syscall_handler = CheatableSysCallHandler(**syscall_dependencies)
-
         hint_locals: dict[str, Any] = {}
 
         cheatcode_factory = CheatableExecuteEntryPoint.cheatcode_factory
@@ -154,8 +150,17 @@ class CheatableExecuteEntryPoint(ExecuteEntryPoint):
         ), "Tried to use CheatableExecuteEntryPoint without cheatcodes."
 
         cheatcodes = cheatcode_factory.build_cheatcodes(
-            syscall_dependencies=syscall_dependencies,
-            internal_calls=syscall_handler.internal_calls,
+            syscall_dependencies=Cheatcode.SyscallDependencies(
+                execute_entry_point_cls=CheatableExecuteEntryPoint,
+                tx_execution_context=tx_execution_context,
+                state=state,
+                resources_manager=resources_manager,
+                caller_address=self.caller_address,
+                contract_address=self.contract_address,
+                general_config=general_config,
+                initial_syscall_ptr=initial_syscall_ptr,
+                shared_internal_calls=syscall_handler.internal_calls,
+            )
         )
         for cheatcode in cheatcodes:
             hint_locals[cheatcode.name] = cheatcode.build()

--- a/protostar/starknet/cheatcode.py
+++ b/protostar/starknet/cheatcode.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Type
 
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.starknet.business_logic.execution.objects import (
+    CallInfo,
     TransactionExecutionContext,
 )
 from starkware.starknet.business_logic.fact_state.state import ExecutionResourcesManager
@@ -32,12 +33,23 @@ class Cheatcode(BusinessLogicSysCallHandler, HintLocal):
         contract_address: int
         general_config: StarknetGeneralConfig
         initial_syscall_ptr: RelocatableValue
+        shared_internal_calls: list[CallInfo]
 
     def __init__(
         self,
         syscall_dependencies: SyscallDependencies,
     ):
-        super().__init__(**syscall_dependencies)
+        super().__init__(
+            execute_entry_point_cls=syscall_dependencies["execute_entry_point_cls"],
+            tx_execution_context=syscall_dependencies["tx_execution_context"],
+            state=syscall_dependencies["state"],
+            resources_manager=syscall_dependencies["resources_manager"],
+            caller_address=syscall_dependencies["caller_address"],
+            contract_address=syscall_dependencies["contract_address"],
+            general_config=syscall_dependencies["general_config"],
+            initial_syscall_ptr=syscall_dependencies["initial_syscall_ptr"],
+        )
+        self.internal_calls = syscall_dependencies["shared_internal_calls"]
 
         # assigning properties to preserve "cheatable" types
         self.state: SyncState = syscall_dependencies["state"]

--- a/protostar/starknet/cheatcode_factory.py
+++ b/protostar/starknet/cheatcode_factory.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from starkware.starknet.business_logic.execution.objects import CallInfo
-
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.starknet.hint_local import HintLocal
 
@@ -10,9 +8,7 @@ from protostar.starknet.hint_local import HintLocal
 class CheatcodeFactory(ABC):
     @abstractmethod
     def build_cheatcodes(
-        self,
-        syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
+        self, syscall_dependencies: Cheatcode.SyscallDependencies
     ) -> List[Cheatcode]:
         ...
 

--- a/protostar/testing/cheatcodes/deploy_cheatcode.py
+++ b/protostar/testing/cheatcodes/deploy_cheatcode.py
@@ -1,7 +1,6 @@
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 from starkware.python.utils import to_bytes
-from starkware.starknet.business_logic.execution.objects import CallInfo
 from starkware.starknet.services.api.contract_class import EntryPointType
 
 from protostar.migrator.cheatcodes.migrator_deploy_contract_cheatcode import (
@@ -17,15 +16,6 @@ from .prepare_cheatcode import PreparedContract
 
 
 class DeployCheatcode(Cheatcode):
-    def __init__(
-        self,
-        syscall_dependencies: Cheatcode.SyscallDependencies,
-        cheatable_syscall_internal_calls: List[CallInfo],
-    ):
-        super().__init__(syscall_dependencies)
-        # fixes https://github.com/software-mansion/protostar/issues/398
-        self.internal_calls = cheatable_syscall_internal_calls
-
     @property
     def name(self) -> str:
         return "deploy"

--- a/protostar/testing/environments/common_test_cheatcode_factory.py
+++ b/protostar/testing/environments/common_test_cheatcode_factory.py
@@ -1,7 +1,5 @@
 from typing import List
 
-from starkware.starknet.business_logic.execution.objects import CallInfo
-
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.starknet.cheatcode_factory import CheatcodeFactory
 from protostar.starknet.hint_local import HintLocal
@@ -31,14 +29,13 @@ class CommonTestCheatcodeFactory(CheatcodeFactory):
     def build_cheatcodes(
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
     ) -> List[Cheatcode]:
         declare_cheatcode = DeclareCheatcode(
             syscall_dependencies,
             self._state.project_compiler,
         )
         prepare_cheatcode = PrepareCheatcode(syscall_dependencies)
-        deploy_cheatcode = DeployCheatcode(syscall_dependencies, internal_calls)
+        deploy_cheatcode = DeployCheatcode(syscall_dependencies)
         return [
             declare_cheatcode,
             prepare_cheatcode,

--- a/protostar/testing/environments/fuzz_test_execution_environment.py
+++ b/protostar/testing/environments/fuzz_test_execution_environment.py
@@ -1,20 +1,21 @@
 import dataclasses
+import logging
 from asyncio import to_thread
 from dataclasses import dataclass
-from typing import Any, Dict, List, Callable
-import logging
+from typing import Any, Callable, Dict, List
 
-from hypothesis import given, seed, settings, example, Phase
+from hypothesis import Phase, example, given, seed, settings
 from hypothesis.database import ExampleDatabase, InMemoryExampleDatabase
 from hypothesis.errors import InvalidArgument
 from hypothesis.reporting import with_reporter
 from hypothesis.strategies import SearchStrategy
-from starkware.starknet.business_logic.execution.objects import CallInfo
 
+from protostar.protostar_exception import ProtostarException
 from protostar.starknet import ReportedException
+from protostar.starknet.abi import get_function_parameters
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.testing.cheatcodes import AssumeCheatcode, RejectCheatcode
-from protostar.testing.fuzzing.exceptions import HypothesisRejectException, FuzzingError
+from protostar.testing.fuzzing.exceptions import FuzzingError, HypothesisRejectException
 from protostar.testing.fuzzing.fuzz_input_exception_metadata import (
     FuzzInputExceptionMetadata,
 )
@@ -29,9 +30,6 @@ from protostar.testing.starkware.execution_resources_summary import (
     ExecutionResourcesSummary,
 )
 from protostar.testing.starkware.test_execution_state import TestExecutionState
-from protostar.starknet.abi import get_function_parameters
-from protostar.protostar_exception import ProtostarException
-
 
 from .test_execution_environment import (
     TestCaseCheatcodeFactory,
@@ -224,10 +222,9 @@ class FuzzTestCaseCheatcodeFactory(TestCaseCheatcodeFactory):
     def build_cheatcodes(
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
     ) -> List[Cheatcode]:
         return [
-            *super().build_cheatcodes(syscall_dependencies, internal_calls),
+            *super().build_cheatcodes(syscall_dependencies),
             RejectCheatcode(syscall_dependencies),
             AssumeCheatcode(syscall_dependencies),
         ]

--- a/protostar/testing/environments/setup_case_execution_environment.py
+++ b/protostar/testing/environments/setup_case_execution_environment.py
@@ -1,10 +1,8 @@
 from typing import List
 
-from starkware.starknet.business_logic.execution.objects import CallInfo
-
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.starknet.hint_local import HintLocal
-from protostar.testing.cheatcodes import GivenCheatcode, SkipCheatcode, ExampleCheatcode
+from protostar.testing.cheatcodes import ExampleCheatcode, GivenCheatcode, SkipCheatcode
 from protostar.testing.fuzzing.strategies import StrategiesHintLocal
 
 from .setup_execution_environment import (
@@ -25,10 +23,9 @@ class SetupCaseCheatcodeFactory(SetupCheatcodeFactory):
     def build_cheatcodes(
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
     ) -> List[Cheatcode]:
         return [
-            *super().build_cheatcodes(syscall_dependencies, internal_calls),
+            *super().build_cheatcodes(syscall_dependencies),
             GivenCheatcode(syscall_dependencies, self._state.config),
             ExampleCheatcode(syscall_dependencies, self._state.config),
             SkipCheatcode(syscall_dependencies),

--- a/protostar/testing/environments/setup_execution_environment.py
+++ b/protostar/testing/environments/setup_execution_environment.py
@@ -1,12 +1,8 @@
 from typing import List
 
-from starkware.starknet.business_logic.execution.objects import CallInfo
-
 from protostar.starknet.cheatcode import Cheatcode
 from protostar.testing.cheatcodes import MaxExamplesCheatcode
-from protostar.testing.environments.execution_environment import (
-    ExecutionEnvironment,
-)
+from protostar.testing.environments.execution_environment import ExecutionEnvironment
 from protostar.testing.starkware.test_execution_state import TestExecutionState
 
 from .common_test_cheatcode_factory import CommonTestCheatcodeFactory
@@ -29,9 +25,8 @@ class SetupCheatcodeFactory(CommonTestCheatcodeFactory):
     def build_cheatcodes(
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
     ) -> List[Cheatcode]:
         return [
-            *super().build_cheatcodes(syscall_dependencies, internal_calls),
+            *super().build_cheatcodes(syscall_dependencies),
             MaxExamplesCheatcode(syscall_dependencies, self._state.config),
         ]

--- a/protostar/testing/environments/test_execution_environment.py
+++ b/protostar/testing/environments/test_execution_environment.py
@@ -1,20 +1,15 @@
 from dataclasses import dataclass
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
-from starkware.starknet.business_logic.execution.objects import CallInfo
-
+from protostar.starknet.abi import has_function_parameters
 from protostar.starknet.cheatcode import Cheatcode
-from protostar.testing.cheatcodes import (
-    ExpectEventsCheatcode,
-    ExpectRevertCheatcode,
-)
+from protostar.testing.cheatcodes import ExpectEventsCheatcode, ExpectRevertCheatcode
 from protostar.testing.cheatcodes.expect_revert_cheatcode import ExpectRevertContext
+from protostar.testing.hook import Hook
 from protostar.testing.starkware.execution_resources_summary import (
     ExecutionResourcesSummary,
 )
 from protostar.testing.starkware.test_execution_state import TestExecutionState
-from protostar.starknet.abi import has_function_parameters
-from protostar.testing.hook import Hook
 
 from .common_test_cheatcode_factory import CommonTestCheatcodeFactory
 from .execution_environment import ExecutionEnvironment
@@ -86,10 +81,9 @@ class TestCaseCheatcodeFactory(CommonTestCheatcodeFactory):
     def build_cheatcodes(
         self,
         syscall_dependencies: Cheatcode.SyscallDependencies,
-        internal_calls: List[CallInfo],
     ) -> List[Cheatcode]:
         return [
-            *super().build_cheatcodes(syscall_dependencies, internal_calls),
+            *super().build_cheatcodes(syscall_dependencies),
             ExpectRevertCheatcode(
                 syscall_dependencies,
                 self._expect_revert_context,

--- a/tests/integration/cheatcodes/send_message_to_l2/external_contract_with_l1_handler.cairo
+++ b/tests/integration/cheatcodes/send_message_to_l2/external_contract_with_l1_handler.cairo
@@ -1,40 +1,25 @@
 %lang starknet
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
-
 @storage_var
 func state() -> (res: felt) {
 }
 
+@event
+func fake_event() {
+}
+
 @l1_handler
-func existing_handler{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-    }(from_address: felt, value: felt){
+func existing_handler{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_address: felt, value: felt
+) {
     fake_event.emit();
     state.write(value);
     return ();
 }
 
 @view
-func get_state{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-    }() -> (res: felt) {
+func get_state{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (res: felt) {
     let (res) = state.read();
     return (res=res);
-}
-
-
-@event
-func fake_event() {
-}
-
-@constructor
-func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-) {
-    fake_event.emit();
-    return ();
 }

--- a/tests/integration/cheatcodes/send_message_to_l2/external_contract_with_l1_handler.cairo
+++ b/tests/integration/cheatcodes/send_message_to_l2/external_contract_with_l1_handler.cairo
@@ -12,6 +12,7 @@ func existing_handler{
         pedersen_ptr: HashBuiltin*,
         range_check_ptr,
     }(from_address: felt, value: felt){
+    fake_event.emit();
     state.write(value);
     return ();
 }
@@ -26,3 +27,14 @@ func get_state{
     return (res=res);
 }
 
+
+@event
+func fake_event() {
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+) {
+    fake_event.emit();
+    return ();
+}

--- a/tests/integration/cheatcodes/send_message_to_l2/send_message_to_l2_test.py
+++ b/tests/integration/cheatcodes/send_message_to_l2/send_message_to_l2_test.py
@@ -28,19 +28,18 @@ def test_l1_to_l2_message_cheatcode(
         testing_summary = asyncio.run(
             run_cairo_test_runner(
                 Path("."),
-                test_cases=["test_sending_events_from_test_case_and_l1_handler"],
             )
         )
 
         assert_cairo_test_cases(
             testing_summary,
             expected_passed_test_cases_names=[
-                # "test_existing_self_l1_handle_call",
-                # "test_existing_self_l1_handle_call_w_transformer",
-                # "test_existing_self_l1_handle_call_no_calldata",
-                # "test_existing_self_l1_handle_call_custom_l1_sender_address",
-                # "test_existing_external_contract_l1_handle_call",
-                "test_sending_events_from_test_case_and_l1_handler"
+                "test_existing_self_l1_handle_call",
+                "test_existing_self_l1_handle_call_w_transformer",
+                "test_existing_self_l1_handle_call_no_calldata",
+                "test_existing_self_l1_handle_call_custom_l1_sender_address",
+                "test_existing_external_contract_l1_handle_call",
+                "test_sending_events_from_test_case_and_l1_handler",
             ],
-            # expected_broken_test_cases_names=["test_non_existing_self_l1_handle_call"],
+            expected_broken_test_cases_names=["test_non_existing_self_l1_handle_call"],
         )

--- a/tests/integration/cheatcodes/send_message_to_l2/send_message_to_l2_test.py
+++ b/tests/integration/cheatcodes/send_message_to_l2/send_message_to_l2_test.py
@@ -2,9 +2,9 @@ import asyncio
 from pathlib import Path
 
 from tests.integration.conftest import (
+    CreateProtostarProjectFixture,
     RunCairoTestRunnerFixture,
     assert_cairo_test_cases,
-    CreateProtostarProjectFixture,
 )
 
 
@@ -25,16 +25,22 @@ def test_l1_to_l2_message_cheatcode(
         )
         protostar.build_sync()
 
-        testing_summary = asyncio.run(run_cairo_test_runner(Path(".")))
+        testing_summary = asyncio.run(
+            run_cairo_test_runner(
+                Path("."),
+                test_cases=["test_sending_events_from_test_case_and_l1_handler"],
+            )
+        )
 
         assert_cairo_test_cases(
             testing_summary,
             expected_passed_test_cases_names=[
-                "test_existing_self_l1_handle_call",
-                "test_existing_self_l1_handle_call_w_transformer",
-                "test_existing_self_l1_handle_call_no_calldata",
-                "test_existing_self_l1_handle_call_custom_l1_sender_address",
-                "test_existing_external_contract_l1_handle_call",
+                # "test_existing_self_l1_handle_call",
+                # "test_existing_self_l1_handle_call_w_transformer",
+                # "test_existing_self_l1_handle_call_no_calldata",
+                # "test_existing_self_l1_handle_call_custom_l1_sender_address",
+                # "test_existing_external_contract_l1_handle_call",
+                "test_sending_events_from_test_case_and_l1_handler"
             ],
-            expected_broken_test_cases_names=["test_non_existing_self_l1_handle_call"],
+            # expected_broken_test_cases_names=["test_non_existing_self_l1_handle_call"],
         )

--- a/tests/integration/cheatcodes/send_message_to_l2/simple_l1_handler_test.cairo
+++ b/tests/integration/cheatcodes/send_message_to_l2/simple_l1_handler_test.cairo
@@ -1,17 +1,14 @@
 %lang starknet
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
-
 @storage_var
 func state() -> (res: felt) {
 }
 
 @l1_handler
-func existing_handler{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-    }(from_address: felt, value: felt){
+func existing_handler{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_address: felt, value: felt
+) {
     state.write(value);
     return ();
 }
@@ -20,10 +17,8 @@ const ALLOWED_L1_SENDER_ADDRESS = 123;
 
 @l1_handler
 func existing_handler_verifying_sender_address{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-    }(from_address: felt, value: felt){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(from_address: felt, value: felt) {
     assert from_address = ALLOWED_L1_SENDER_ADDRESS;
     state.write(value);
     return ();
@@ -32,22 +27,17 @@ func existing_handler_verifying_sender_address{
 const PREDEFINED_VALUE = 'somevalue';
 
 @l1_handler
-func existing_handler_no_calldata{
-        syscall_ptr: felt*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr,
-    }(from_address: felt){
+func existing_handler_no_calldata{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_address: felt
+) {
     state.write(PREDEFINED_VALUE);
     return ();
 }
 
-
 @external
 func test_existing_self_l1_handle_call{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     let STATE_AFTER = 'self_l1_handle_call';
 
     %{ send_message_to_l2("existing_handler", payload=[ids.STATE_AFTER]) %}
@@ -60,10 +50,8 @@ func test_existing_self_l1_handle_call{
 
 @external
 func test_existing_self_l1_handle_call_no_calldata{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     %{ send_message_to_l2("existing_handler_no_calldata") %}
 
     let (state_after_l1_msg) = state.read();
@@ -74,10 +62,8 @@ func test_existing_self_l1_handle_call_no_calldata{
 
 @external
 func test_existing_self_l1_handle_call_w_transformer{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     let STATE_AFTER = 'self_l1_handle_call';
 
     %{ send_message_to_l2("existing_handler", payload={"value": ids.STATE_AFTER}) %}
@@ -90,10 +76,8 @@ func test_existing_self_l1_handle_call_w_transformer{
 
 @external
 func test_non_existing_self_l1_handle_call{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     let STATE_AFTER = 'self_l1_handle_call';
 
     %{ send_message_to_l2("non_existing_handler", payload={"value": ids.STATE_AFTER}) %}
@@ -102,10 +86,8 @@ func test_non_existing_self_l1_handle_call{
 
 @external
 func test_existing_self_l1_handle_call_custom_l1_sender_address{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     let STATE_AFTER = 'self_l1_handle_call';
 
     %{
@@ -121,8 +103,6 @@ func test_existing_self_l1_handle_call_custom_l1_sender_address{
     return ();
 }
 
-
-
 @contract_interface
 namespace ExternalContractInterface {
     func get_state() -> (res: felt) {
@@ -131,10 +111,8 @@ namespace ExternalContractInterface {
 
 @external
 func test_existing_external_contract_l1_handle_call{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     alloc_locals;
     local external_contract_address: felt;
     let secret_value = 's3cr3t';
@@ -158,34 +136,20 @@ func test_existing_external_contract_l1_handle_call{
 func fake_event() {
 }
 
-
 @external
-func test_tmp{
-    syscall_ptr: felt*,
-    pedersen_ptr: HashBuiltin*,
-    range_check_ptr,
-}(){
-    alloc_locals;
-    local external_contract_address: felt;
-    let secret_value = 's3cr3t';
-    fake_event.emit();
-    fake_event.emit();
-    %{ ids.external_contract_address = deploy_contract("tests/integration/cheatcodes/send_message_to_l2/external_contract_with_l1_handler.cairo").contract_address %}
+func test_sending_events_from_test_case_and_l1_handler{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
     %{
+        contract_address = deploy_contract("src/main.cairo").contract_address 
         send_message_to_l2(
             fn_name="existing_handler",
             from_address=123,
-            payload=[ids.secret_value],
-            to_address=ids.external_contract_address,
+            payload=[123],
+            to_address=contract_address,
         )
     %}
     fake_event.emit();
 
-    let (state) = ExternalContractInterface.get_state(contract_address=external_contract_address);
-
-
-    
-    assert state = secret_value;
     return ();
 }
-

--- a/tests/integration/cheatcodes/send_message_to_l2/simple_l1_handler_test.cairo
+++ b/tests/integration/cheatcodes/send_message_to_l2/simple_l1_handler_test.cairo
@@ -140,6 +140,11 @@ func fake_event() {
 func test_sending_events_from_test_case_and_l1_handler{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }() {
+    // This test protects against regression.
+    // Cheatcodes as syscall handlers mess up StarkNet's logic resulting in the following error:
+    // "starkware/starknet/business_logic/execution/objects.py", line 337, in get_sorted_events
+    // IndexError: list assignment index out of range
+    // https://github.com/software-mansion/protostar/issues/1065
     %{
         contract_address = deploy_contract("src/main.cairo").contract_address 
         send_message_to_l2(

--- a/tests/integration/cheatcodes/send_message_to_l2/simple_l1_handler_test.cairo
+++ b/tests/integration/cheatcodes/send_message_to_l2/simple_l1_handler_test.cairo
@@ -153,3 +153,39 @@ func test_existing_external_contract_l1_handle_call{
     assert state = secret_value;
     return ();
 }
+
+@event
+func fake_event() {
+}
+
+
+@external
+func test_tmp{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr,
+}(){
+    alloc_locals;
+    local external_contract_address: felt;
+    let secret_value = 's3cr3t';
+    fake_event.emit();
+    fake_event.emit();
+    %{ ids.external_contract_address = deploy_contract("tests/integration/cheatcodes/send_message_to_l2/external_contract_with_l1_handler.cairo").contract_address %}
+    %{
+        send_message_to_l2(
+            fn_name="existing_handler",
+            from_address=123,
+            payload=[ids.secret_value],
+            to_address=ids.external_contract_address,
+        )
+    %}
+    fake_event.emit();
+
+    let (state) = ExternalContractInterface.get_state(contract_address=external_contract_address);
+
+
+    
+    assert state = secret_value;
+    return ();
+}
+


### PR DESCRIPTION
Fix crash caused by `send_message_to_l2` cheatcode. Fix the problem in the `Cheatcode` class to avoid reintroducing this problem by new cheatcodes.

Fixes #1065 