### PR TITLE
Redesigning `protostar.toml` 17 — Connect `migrate-configuration-file` command

### DIFF
--- a/protostar/commands/migrate_configuration_file_command.py
+++ b/protostar/commands/migrate_configuration_file_command.py
@@ -22,7 +22,7 @@ class MigrateConfigurationFileCommand(ProtostarCommand):
 
     @property
     def description(self) -> str:
-        return "Migrate protostar.toml to the new version introduced in Protostar v0.5"
+        return "Migrate protostar.toml V1 to V2."
 
     @property
     def example(self) -> Optional[str]:

--- a/protostar/commands/migrate_configuration_file_command.py
+++ b/protostar/commands/migrate_configuration_file_command.py
@@ -7,6 +7,8 @@ from protostar.configuration_file import ConfigurationFileMigratorProtocol
 
 
 class MigrateConfigurationFileCommand(ProtostarCommand):
+    NAME = "migrate-configuration-file"
+
     def __init__(
         self,
         logger: Logger,
@@ -18,7 +20,7 @@ class MigrateConfigurationFileCommand(ProtostarCommand):
 
     @property
     def name(self) -> str:
-        return "migrate-configuration-file"
+        return self.NAME
 
     @property
     def description(self) -> str:

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -211,6 +211,7 @@ def build_di_container(
         logger=logger,
         version_manager=version_manager,
         project_cairo_path_builder=project_cairo_path_builder,
+        configuration_file=configuration_file,
         start_time=start_time,
     )
     if configuration_file:

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -17,6 +17,7 @@ from protostar.commands import (
     InstallCommand,
     InvokeCommand,
     MigrateCommand,
+    MigrateConfigurationFileCommand,
     RemoveCommand,
     TestCommand,
     UpdateCommand,
@@ -33,6 +34,7 @@ from protostar.configuration_file import (
     ConfigurationFileFactory,
     ConfigurationFileV1,
     ConfigurationFileV2ContentFactory,
+    ConfigurationFileV2Migrator,
     ConfigurationTOMLContentBuilder,
 )
 from protostar.io import InputRequester, log_color_provider
@@ -123,6 +125,17 @@ def build_di_container(
         protostar_version=protostar_version,
     )
 
+    migrate_configuration_file_command = MigrateConfigurationFileCommand(
+        logger=logger,
+        configuration_file_migrator=ConfigurationFileV2Migrator(
+            protostar_version=protostar_version,
+            current_configuration_file=configuration_file,
+            content_factory=ConfigurationFileV2ContentFactory(
+                content_builder=ConfigurationTOMLContentBuilder()
+            ),
+        ),
+    )
+
     commands: list[ProtostarCommand] = [
         InitCommand(
             requester=input_requester,
@@ -188,6 +201,7 @@ def build_di_container(
         DeployAccountCommand(
             gateway_facade_factory=gateway_facade_factory, logger=logger
         ),
+        migrate_configuration_file_command,
     ]
 
     protostar_cli = ProtostarCLI(

--- a/protostar/configuration_profile_cli.py
+++ b/protostar/configuration_profile_cli.py
@@ -6,24 +6,7 @@ class ConfigurationProfileCLI(CLIApp):
         name="profile",
         short_name="p",
         type="str",
-        description="\n".join(
-            [
-                "Specifies active profile configuration. This argument can't be configured in `protostar.toml`.",
-                "#### CI configuration",
-                '```toml title="protostar.toml"',
-                "[profile.ci.protostar.shared_command_configs]",
-                "no_color=true",
-                "```",
-                "`protostar -p ci test`",
-                "",
-                "#### Deployment configuration",
-                '```toml title="protostar.toml"',
-                "[profile.devnet.protostar.deploy]",
-                'gateway_url="http://127.0.0.1:5050/"',
-                "```",
-                "`protostar -p devnet deploy ...`" "",
-            ]
-        ),
+        description="Specifies active configuration profile defined in the configuration file.",
     )
 
     def __init__(self) -> None:

--- a/protostar/protostar_cli_test.py
+++ b/protostar/protostar_cli_test.py
@@ -68,6 +68,7 @@ def protostar_cli_fixture(
         logger=logger,
         version_manager=version_manager,
         latest_version_checker=latest_version_checker,
+        configuration_file=mocker.MagicMock(),
         project_cairo_path_builder=mocker.MagicMock(),
     )
 

--- a/tests/e2e/test_misc_commands.py
+++ b/tests/e2e/test_misc_commands.py
@@ -107,5 +107,6 @@ def test_migrate_configuration_file(protostar: ProtostarFixture):
     configuration_file = Path("protostar.toml").read_text(encoding="utf-8")
 
     assert "The configuration file was migrated successfully" in output
+    assert "update your configuration file" not in output
     assert "[project]" in configuration_file
     assert '"src/main.cairo"' in configuration_file

--- a/tests/e2e/test_misc_commands.py
+++ b/tests/e2e/test_misc_commands.py
@@ -2,6 +2,7 @@
 import re
 from os import listdir
 from pathlib import Path
+from textwrap import dedent
 
 import pexpect
 import pytest
@@ -81,3 +82,30 @@ def test_protostar_version_in_correct_format(protostar: ProtostarFixture):
     assert isinstance(
         v_object, Version
     ), f"Output version ({v_string}) does not meet the format requirements"
+
+
+def test_migrate_configuration_file(protostar: ProtostarFixture):
+    Path("protostar.toml").write_text(
+        dedent(
+            """
+        ["protostar.config"]
+        protostar_version = "0.5.0"
+
+        ["protostar.project"]
+        libs_path = "./lib"         
+
+        ["protostar.contracts"]
+        main = [
+        "./src/main.cairo",
+        ]
+    """
+        ),
+        encoding="utf-8",
+    )
+
+    output = protostar(["migrate-configuration-file"])
+    configuration_file = Path("protostar.toml").read_text(encoding="utf-8")
+
+    assert "The configuration file was migrated successfully" in output
+    assert "[project]" in configuration_file
+    assert '"src/main.cairo"' in configuration_file

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -3,20 +3,7 @@
 #### `--no-color`
 Disable colors.
 #### `-p` `--profile STRING`
-Specifies active profile configuration. This argument can't be configured in `protostar.toml`.
-#### CI configuration
-```toml title="protostar.toml"
-[profile.ci.protostar.shared_command_configs]
-no_color=true
-```
-`protostar -p ci test`
-
-#### Deployment configuration
-```toml title="protostar.toml"
-[profile.devnet.protostar.deploy]
-gateway_url="http://127.0.0.1:5050/"
-```
-`protostar -p devnet deploy ...`
+Specifies active configuration profile defined in the configuration file.
 #### `-v` `--version`
 Show Protostar and Cairo-lang version.
 ## Commands

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -267,7 +267,7 @@ Can be used instead of PROTOSTAR_ACCOUNT_PRIVATE_KEY env variable.
 #### `--signer-class STRING`
 Custom signer class module path.
 ### `migrate-configuration-file`
-Migrate protostar.toml to the new version introduced in Protostar v0.5
+Migrate protostar.toml V1 to V2.
 ### `remove`
 ```shell
 $ protostar remove cairo-contracts

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -266,6 +266,8 @@ Path to the file, which stores your private key (in hex representation) for the 
 Can be used instead of PROTOSTAR_ACCOUNT_PRIVATE_KEY env variable.
 #### `--signer-class STRING`
 Custom signer class module path.
+### `migrate-configuration-file`
+Migrate protostar.toml to the new version introduced in Protostar v0.5
 ### `remove`
 ```shell
 $ protostar remove cairo-contracts


### PR DESCRIPTION
Allow migrating configuration files. Show depreciation warning. Add E2E test.

Related #477 