### PR TITLE
Remove rollback from migrations

### DIFF
--- a/protostar/commands/migrate_command.py
+++ b/protostar/commands/migrate_command.py
@@ -59,11 +59,6 @@ class MigrateCommand(ProtostarCommand):
                 is_positional=True,
             ),
             ProtostarArgument(
-                name="rollback",
-                description="Run `rollback` function in the migration script.",
-                type="bool",
-            ),
-            ProtostarArgument(
                 name="no-confirm",
                 description="Skip confirming building the project.",
                 type="bool",
@@ -87,7 +82,6 @@ class MigrateCommand(ProtostarCommand):
 
         return await self.migrate(
             migration_file_path=args.path,
-            rollback=args.rollback,
             gateway_client=network_command_util.get_gateway_client(),
             no_confirm=args.no_confirm,
             migrator_config=migrator_config,
@@ -98,7 +92,6 @@ class MigrateCommand(ProtostarCommand):
     async def migrate(
         self,
         migration_file_path: Path,
-        rollback: bool,
         gateway_client: GatewayClient,
         migrator_config: MigratorExecutionEnvironment.Config,
         no_confirm: bool,
@@ -134,7 +127,7 @@ class MigrateCommand(ProtostarCommand):
         )
 
         try:
-            migrator_history = await migrator.run(rollback)
+            migrator_history = await migrator.run()
             migrator.save_history(migrator_history, migration_file_path.parent)
             self._logger.info("Migration completed")
 

--- a/protostar/commands/migrate_command_test.py
+++ b/protostar/commands/migrate_command_test.py
@@ -6,11 +6,11 @@ import pytest
 from pytest_mock import MockerFixture
 from starknet_py.net.gateway_client import GatewayClient
 
+from protostar.io.input_requester import InputRequester
 from protostar.migrator import Migrator
 from protostar.protostar_exception import ProtostarException
 from protostar.starknet import CheatcodeException
 from protostar.starknet_gateway import GatewayFacadeFactory
-from protostar.io.input_requester import InputRequester
 
 from .migrate_command import MigrateCommand
 
@@ -52,7 +52,6 @@ def setup_migrate(mocker: MockerFixture):
     async def migrate(no_confirm: bool):
         await migrate_command.migrate(
             migration_file_path=Path(),
-            rollback=False,
             no_confirm=no_confirm,
             gateway_client=GatewayClient("http://localhost:3000/"),
             migrator_config=mocker.MagicMock(),
@@ -80,7 +79,6 @@ async def test_cheatcode_exceptions_are_pretty_printed(mocker: MockerFixture):
         await migrate_command.migrate(
             gateway_client=mocker.MagicMock(),
             migration_file_path=Path(),
-            rollback=False,
             no_confirm=True,
             migrator_config=mocker.MagicMock(),
             compiled_contracts_dir_path=Path(),

--- a/protostar/migrator/migrator.py
+++ b/protostar/migrator/migrator.py
@@ -7,15 +7,15 @@ from typing import List, Optional
 
 from starknet_py.net.signer import BaseSigner
 
+from protostar.io.log_color_provider import LogColorProvider
 from protostar.migrator.migrator_execution_environment import (
     MigratorExecutionEnvironment,
 )
 from protostar.starknet_gateway import GatewayFacade
 from protostar.starknet_gateway.starknet_request import StarknetRequest
-from protostar.io.log_color_provider import LogColorProvider
 
-from .output_directory import create_output_directory
 from .migrator_datetime_state import MigratorDateTimeState
+from .output_directory import create_output_directory
 
 
 class Migrator:
@@ -97,14 +97,12 @@ class Migrator:
         self._migrator_execution_environment = migrator_execution_environment
         self._migrator_datetime_state = migrator_datetime_state
 
-    async def run(self, rollback: bool = False) -> History:
+    async def run(self) -> History:
         self._migrator_datetime_state.update_to_now()
         with create_output_directory(
             self._migrator_datetime_state.get_compilation_output_path()
         ):
-            await self._migrator_execution_environment.execute(
-                function_name="down" if rollback else "up"
-            )
+            await self._migrator_execution_environment.execute(function_name="up")
 
         return Migrator.History(starknet_requests=self._get_sent_requests())
 

--- a/tests/integration/migrator/migrator_test.py
+++ b/tests/integration/migrator/migrator_test.py
@@ -19,7 +19,6 @@ def protostar_fixture(create_protostar_project: CreateProtostarProjectFixture):
 def migration_file_path_fixture(protostar: ProtostarFixture) -> Path:
     return protostar.create_migration_file(
         up_hint_content='deploy_contract("./build/main.json")',
-        down_hint_content='declare("./build/main.json")',
     )
 
 
@@ -31,13 +30,3 @@ async def test_migrate_up(
     )
 
     assert result.starknet_requests[0].action == "DEPLOY"
-
-
-async def test_migrate_down(
-    protostar: ProtostarFixture, migration_file_path: Path, devnet_gateway_url: str
-):
-    result = await protostar.migrate(
-        migration_file_path, gateway_url=devnet_gateway_url, rollback=True
-    )
-
-    assert result.starknet_requests[0].action == "DECLARE"

--- a/tests/integration/protostar_fixture.py
+++ b/tests/integration/protostar_fixture.py
@@ -15,12 +15,12 @@ from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
 from protostar.cli.map_targets_to_file_paths import map_targets_to_file_paths
 from protostar.commands import (
     BuildCommand,
+    CallCommand,
     DeclareCommand,
     FormatCommand,
     InitCommand,
     InvokeCommand,
     MigrateCommand,
-    CallCommand,
 )
 from protostar.commands.deploy_command import DeployCommand
 from protostar.commands.init.project_creator.new_project_creator import (
@@ -170,12 +170,10 @@ class ProtostarFixture:
         self,
         path: Path,
         gateway_url: str,
-        rollback: bool = False,
         account_address: Optional[str] = None,
     ):
         args = Namespace()
         args.path = path
-        args.rollback = rollback
         args.no_confirm = True
         args.network = None
         args.gateway_url = gateway_url
@@ -288,15 +286,6 @@ class ProtostarFixture:
         func up(){{
             %{{
                 {up_hint_content}
-            %}}
-
-            return ();
-        }}
-
-        @external
-        func down(){{
-            %{{
-                {down_hint_content}
             %}}
 
             return ();

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -224,8 +224,6 @@ Skip confirming building the project.
 #### `--private-key-path PATH`
 Path to the file, which stores your private key (in hex representation) for the account. 
 Can be used instead of PROTOSTAR_ACCOUNT_PRIVATE_KEY env variable.
-#### `--rollback`
-Run `rollback` function in the migration script.
 #### `--signer-class STRING`
 Custom signer class module path.
 ### `remove`

--- a/website/docs/tutorials/06-deploying/02-migrations/README.md
+++ b/website/docs/tutorials/06-deploying/02-migrations/README.md
@@ -12,13 +12,13 @@ Breaking changes can be introduced without deprecation. StarkNet [deployment flo
 Migrations are Cairo files that help you manage contracts on the StarkNet.
 These files are responsible for staging your deployment tasks, and they're written under the assumption that your project uses [Proxy Pattern](https://blog.openzeppelin.com/proxy-patterns/).
 As your project evolves, you'll create new migration scripts to reflect this evolution on the Starknet.
-To interact with StarkNet, you can use [migration cheatcodes](#available-migration-cheatcodes). 
+
 
 ## Creating a migration file
-You can create a migration file anywhere, but we recommend creating them inside a `migrations` directory. Currently, Protostar doesn't enforce any naming convention for migration files. In this tutorial we use a naming convention: `migration_NUMBER_TITLE.cairo`, for example `migration_01_init.cairo`.
+You can create a migration file anywhere, but we recommend creating them inside a `migrations` directory. Currently, Protostar doesn't enforce any naming convention for migration files. In this document we use a naming convention: `migration_NUMBER_TITLE.cairo`, for example `migration_01_init.cairo`.
 
 ## Migration file structure
-Each migration should have 2 functions: `up` and `down`. The `up` function is responsible to migrate your project forward, and the `down` function is executed to rollback changes. These functions must be decorated with `@external` decorator.
+The migration needs to have a function `up`. This function should be responsible for migrating your project forward. To interact with StarkNet, use [migration cheatcodes](#available-migration-cheatcodes). 
 
 ```cairo title="Deploying storage and logic contracts"
 %lang starknet
@@ -26,8 +26,8 @@ Each migration should have 2 functions: `up` and `down`. The `up` function is re
 @external
 func up() {
     %{
-        logic_contract_address = deploy_contract("./build/main.json").contract_address
-        storage_contract_address = deploy_contract("./build/proxy.json", [logic_contract_address]).contract_address
+        logic_contract_address = deploy_contract("main").contract_address
+        storage_contract_address = deploy_contract("proxy", [logic_contract_address]).contract_address
     %}
     return ();
 }


### PR DESCRIPTION
Remove rollback functionality from migrations. This functionality creates more confusion than good.

Related #1001 