### PR TITLE
Suggest chain-ids values

### DIFF
--- a/protostar/cli/network_command_util.py
+++ b/protostar/cli/network_command_util.py
@@ -71,7 +71,7 @@ class NetworkCommandUtil:
         return NetworkConfig.build(
             gateway_url=self._args.gateway_url,
             network=self._args.network,
-            chain_id=self.normalize_chain_id(self._args.chain_id),
+            chain_id=self._normalize_chain_id(self._args.chain_id),
         )
 
     def get_gateway_client(self) -> GatewayClient:
@@ -79,7 +79,7 @@ class NetworkCommandUtil:
         return GatewayClient(network_config.gateway_url)
 
     @staticmethod
-    def normalize_chain_id(
+    def _normalize_chain_id(
         arg: Optional[Union[str, StarknetChainId]]
     ) -> Optional[StarknetChainId]:
         if arg is None:
@@ -88,7 +88,13 @@ class NetworkCommandUtil:
         if isinstance(arg, StarknetChainId):
             return arg
 
+        supported_chain_ids: list[str] = []
+        for chain_id in StarknetChainId:
+            supported_chain_ids.append(f"- {chain_id.value} ({chain_id.name})")
         try:
             return StarknetChainId(arg)
         except ValueError as ex:
-            raise ProtostarException("Invalid chain id value.") from ex
+            raise ProtostarException(
+                "Invalid chain id value.\n"
+                "Supported chain ids:\n" + "\n".join(supported_chain_ids)
+            ) from ex

--- a/protostar/cli/network_command_util_test.py
+++ b/protostar/cli/network_command_util_test.py
@@ -1,14 +1,39 @@
 from types import SimpleNamespace
+from typing import Optional, Protocol
 
 import pytest
 from pytest_mock import MockerFixture
 
 from protostar.cli.network_command_util import (
-    NetworkCommandUtil,
     GATEWAY_URL_ARG_NAME,
     NETWORK_ARG_NAME,
+    NetworkCommandUtil,
 )
 from protostar.protostar_exception import ProtostarException
+
+
+class CreateNetworkCommandUtilFixture(Protocol):
+    def __call__(
+        self, network: Optional[str] = None, chain_id: Optional[int] = None
+    ) -> NetworkCommandUtil:
+        ...
+
+
+@pytest.fixture(name="create_network_command_util")
+def create_network_command_util_fixture(
+    mocker: MockerFixture,
+) -> CreateNetworkCommandUtilFixture:
+    def create_network_command_util(
+        network: Optional[str] = None, chain_id: Optional[int] = None
+    ):
+        logger = mocker.MagicMock()
+        args = SimpleNamespace()
+        args.network = network
+        args.gateway_url = None
+        args.chain_id = chain_id
+        return NetworkCommandUtil(args=args, logger=logger)
+
+    return create_network_command_util
 
 
 @pytest.mark.parametrize(
@@ -70,3 +95,13 @@ def test_mixin_throws_on_no_sufficient_args(mocker: MockerFixture):
         f"Argument `{GATEWAY_URL_ARG_NAME}` or `{NETWORK_ARG_NAME}` is required"
         in pex.value.message
     )
+
+
+def test_printing_invalid_chain_id(
+    create_network_command_util: CreateNetworkCommandUtilFixture,
+):
+    network_command_util = create_network_command_util(chain_id=123)
+    with pytest.raises(ProtostarException) as ex:
+        network_command_util.get_network_config()
+        assert "23448594291968334" in str(ex)
+        assert "1536727068981429685321" in str(ex)

--- a/protostar/cli/network_command_util_test.py
+++ b/protostar/cli/network_command_util_test.py
@@ -101,7 +101,9 @@ def test_printing_invalid_chain_id(
     create_network_command_util: CreateNetworkCommandUtilFixture,
 ):
     network_command_util = create_network_command_util(chain_id=123)
+
     with pytest.raises(ProtostarException) as ex:
         network_command_util.get_network_config()
+
         assert "23448594291968334" in str(ex)
         assert "1536727068981429685321" in str(ex)


### PR DESCRIPTION
Show supported chain ID values if invalid is provided. Supported values are hard to memorize. A user needs to provide chain ID explicitly when using Protostar with devnet.

Closes #1074 