### PR TITLE
Add `deploy-account` command

### DIFF
--- a/protostar/cli/network_command_util.py
+++ b/protostar/cli/network_command_util.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from logging import Logger
 from typing import Any, Optional, Union
 
@@ -13,6 +14,12 @@ from .protostar_argument import ProtostarArgument
 GATEWAY_URL_ARG_NAME = "gateway-url"
 NETWORK_ARG_NAME = "network"
 CHAIN_ID_ARG_NAME = "chain-id"
+
+
+@dataclass
+class NetworkArgs:
+    chain_id: Optional[int]
+    gateway_client: GatewayClient
 
 
 class NetworkCommandUtil:

--- a/protostar/cli/protostar_arg_type.py
+++ b/protostar/cli/protostar_arg_type.py
@@ -24,9 +24,9 @@ def map_protostar_type_name_to_parser(
     if argument_type == "fee":
         return parse_fee_arg_type
     if argument_type == "address":
-        return parse_address_arg_type
+        return parse_hex
     if argument_type == "class_hash":
-        return parse_class_hash_arg_type
+        return parse_hex
     if argument_type == "wei":
         return parse_wei_arg_type
     return map_type_name_to_parser(argument_type)
@@ -36,12 +36,6 @@ def parse_felt_arg_type(arg: str) -> int:
     # pylint: disable=unbalanced-tuple-unpacking
     [output] = cast_to_felts([arg])
     return output
-
-
-def parse_class_hash_arg_type(arg: str) -> int:
-    if arg.startswith("0x"):
-        return int(arg, base=16)
-    return int(arg, base=10)
 
 
 def parse_wei_arg_type(arg: str) -> Wei:
@@ -54,7 +48,7 @@ def parse_fee_arg_type(arg: str) -> Fee:
     return int(arg)
 
 
-def parse_address_arg_type(arg: str) -> int:
+def parse_hex(arg: str) -> int:
     if arg.startswith("0x"):
         return int(arg, 16)
     return int(arg)

--- a/protostar/cli/protostar_arg_type.py
+++ b/protostar/cli/protostar_arg_type.py
@@ -24,9 +24,9 @@ def map_protostar_type_name_to_parser(
     if argument_type == "fee":
         return parse_fee_arg_type
     if argument_type == "address":
-        return parse_hex
+        return parse_hex_or_decimal
     if argument_type == "class_hash":
-        return parse_hex
+        return parse_hex_or_decimal
     if argument_type == "wei":
         return parse_wei_arg_type
     return map_type_name_to_parser(argument_type)
@@ -48,7 +48,7 @@ def parse_fee_arg_type(arg: str) -> Fee:
     return int(arg)
 
 
-def parse_hex(arg: str) -> int:
+def parse_hex_or_decimal(arg: str) -> int:
     if arg.startswith("0x"):
         return int(arg, 16)
     return int(arg)

--- a/protostar/cli/protostar_arg_type.py
+++ b/protostar/cli/protostar_arg_type.py
@@ -3,12 +3,14 @@ from typing import Any, Callable, Literal, Union
 from starkware.starknet.utils.api_utils import cast_to_felts
 
 from protostar.argument_parser import ArgTypeName, map_type_name_to_parser
-from protostar.starknet_gateway import Fee
+from protostar.starknet_gateway import Fee, Wei
 
 CustomProtostarArgTypeName = Literal[
     "felt",
+    "wei",
     "fee",
     "address",
+    "class_hash",
 ]
 
 ProtostarArgTypeName = Union[CustomProtostarArgTypeName, ArgTypeName]
@@ -23,7 +25,10 @@ def map_protostar_type_name_to_parser(
         return parse_fee_arg_type
     if argument_type == "address":
         return parse_address_arg_type
-
+    if argument_type == "class_hash":
+        return parse_class_hash_arg_type
+    if argument_type == "wei":
+        return parse_wei_arg_type
     return map_type_name_to_parser(argument_type)
 
 
@@ -31,6 +36,16 @@ def parse_felt_arg_type(arg: str) -> int:
     # pylint: disable=unbalanced-tuple-unpacking
     [output] = cast_to_felts([arg])
     return output
+
+
+def parse_class_hash_arg_type(arg: str) -> int:
+    if arg.startswith("0x"):
+        return int(arg, base=16)
+    return int(arg, base=10)
+
+
+def parse_wei_arg_type(arg: str) -> Wei:
+    return int(float(arg))
 
 
 def parse_fee_arg_type(arg: str) -> Fee:

--- a/protostar/cli/protostar_arg_type_test.py
+++ b/protostar/cli/protostar_arg_type_test.py
@@ -16,6 +16,18 @@ def test_felt_type(test_input: str, expected: int):
     assert result == expected
 
 
+def test_class_hash_type():
+    parse = map_protostar_type_name_to_parser("class_hash")
+    assert parse("0xF") == 15
+    assert parse("15") == 15
+
+
+def test_wei_type():
+    parse = map_protostar_type_name_to_parser("wei")
+    assert parse("1e3") == 1000
+    assert parse("1000") == 1000
+
+
 def test_fee_type():
     parse_fee = map_protostar_type_name_to_parser("fee")
     assert parse_fee("auto") == "auto"

--- a/protostar/cli/signable_command_util.py
+++ b/protostar/cli/signable_command_util.py
@@ -18,7 +18,7 @@ class SignableCommandUtil:
     signable_arguments = [
         ProtostarArgument(
             name="account-address",
-            description="Account address",
+            description="Account address.",
             type="address",
         ),
         ProtostarArgument(

--- a/protostar/commands/__init__.py
+++ b/protostar/commands/__init__.py
@@ -1,6 +1,7 @@
 from .build_command import BuildCommand
 from .call_command import CallCommand
 from .declare_command import DeclareCommand
+from .deploy_account_command import DeployAccountCommand
 from .deploy_command import DeployCommand
 from .format_command import FormatCommand
 from .init import InitCommand

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -72,6 +72,7 @@ class DeployAccountCommand(ProtostarCommand):
     def arguments(self):
         return [
             *NetworkCommandUtil.network_arguments,
+            *SignableCommandUtil.signable_arguments,
         ]
 
     async def run(self, args: Namespace):
@@ -82,6 +83,7 @@ class DeployAccountCommand(ProtostarCommand):
             deploy_account_args=deploy_account_args, typed_args=typed_args
         )
         self._log_response(response)
+        return response
 
     def _validate_cli_args(self, typed_args: DeployAccountCommandArgs):
         if typed_args.max_fee == "auto":

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -1,20 +1,50 @@
 from argparse import Namespace
 from dataclasses import dataclass
-from logging import Logger
+from logging import Logger, getLogger
 from typing import Optional
 
-from protostar.cli import ProtostarArgument, ProtostarCommand
-from protostar.cli.network_command_util import NetworkCommandUtil
+from starknet_py.net.signer import BaseSigner
+
+from protostar.cli import NetworkCommandUtil, ProtostarCommand, SignableCommandUtil
+from protostar.cli.network_command_util import NetworkArgs
+from protostar.protostar_exception import ProtostarException
 from protostar.starknet_gateway import GatewayFacadeFactory
-from protostar.starknet_gateway.gateway_facade import DeployAccountArgs
+from protostar.starknet_gateway.gateway_facade import ClassHash, DeployAccountArgs, Fee
 from protostar.starknet_gateway.gateway_response import SuccessfulDeployAccountResponse
 
 
 @dataclass
-class DeployAccountCommandArgs:
+class DeployAccountCommandArgs(NetworkArgs):
+    account_address: str
+    salt: int
+    account_constructor_input: Optional[list[int]]
+    account_class_hash: ClassHash
+    nonce: int
+    signer: BaseSigner
+    max_fee: Fee
+
     @classmethod
     def from_args(cls, args: Namespace):
-        cls()
+        logger = getLogger()
+        network_util = NetworkCommandUtil(args, logger=logger)
+        network_config = network_util.get_network_config()
+        gateway_client = network_util.get_gateway_client()
+        signer = SignableCommandUtil(args, logger=logger).get_signer(
+            network_config=network_config
+        )
+
+        assert signer is not None
+        return cls(
+            account_address=args.account_address,
+            nonce=args.nonce,
+            account_class_hash=args.account_class_hash,
+            account_constructor_input=args.account_constructor_input or [],
+            salt=args.salt,
+            signer=signer,
+            max_fee=args.max_fee,
+            gateway_client=gateway_client,
+            chain_id=args.chain_id,
+        )
 
 
 class DeployAccountCommand(ProtostarCommand):
@@ -28,11 +58,11 @@ class DeployAccountCommand(ProtostarCommand):
 
     @property
     def name(self) -> str:
-        return "deploy"
+        return "deploy-account"
 
     @property
     def description(self) -> str:
-        return "Deploy contracts."
+        return "Sends deploy-account transaction. The account contract must be already declared and prefunded."
 
     @property
     def example(self) -> Optional[str]:
@@ -46,30 +76,58 @@ class DeployAccountCommand(ProtostarCommand):
 
     async def run(self, args: Namespace):
         typed_args = DeployAccountCommandArgs.from_args(args)
-        if self._validate_cli_args(typed_args):
-            deploy_account_args = self._map_typed_args_to_deploy_account_args(
-                typed_args
-            )
-            response = await self._send_deploy_account_tx(deploy_account_args)
-            self._log_response(response)
+        self._validate_cli_args(typed_args)
+        deploy_account_args = self._map_typed_args_to_deploy_account_args(typed_args)
+        response = await self._send_deploy_account_tx(
+            deploy_account_args=deploy_account_args, typed_args=typed_args
+        )
+        self._log_response(response)
 
-    def _validate_cli_args(self, typed_args: DeployAccountCommandArgs) -> bool:
-        return True
+    def _validate_cli_args(self, typed_args: DeployAccountCommandArgs):
+        if typed_args.max_fee == "auto":
+            raise ProtostarException(
+                "Protostar can't auto-estimate max fee for the DeployAccount transaction."
+            )
 
     def _map_typed_args_to_deploy_account_args(
-        self, typed_args: DeployAccountCommandArgs
+        self,
+        typed_args: DeployAccountCommandArgs,
     ) -> DeployAccountArgs:
-        return DeployAccountArgs()
+        return DeployAccountArgs(
+            account_address=int(typed_args.account_address, base=0),
+            account_class_hash=typed_args.account_class_hash,
+            account_address_salt=typed_args.salt,
+            nonce=typed_args.nonce,
+            signer=typed_args.signer,
+            account_constructor_input=typed_args.account_constructor_input,
+            max_fee=1,
+        )
 
     async def _send_deploy_account_tx(
         self,
         typed_args: DeployAccountCommandArgs,
         deploy_account_args: DeployAccountArgs,
     ):
+
         gateway_facade = self._gateway_facade_factory.create(
             gateway_client=typed_args.gateway_client, logger=None
         )
-        return await gateway_facade.deploy_account()
+        return await gateway_facade.deploy_account(args=deploy_account_args)
 
-    async def _log_response(self, response: SuccessfulDeployAccountResponse):
-        pass
+    def _log_response(self, response: SuccessfulDeployAccountResponse):
+        return self._logger.info(
+            "\n".join(
+                [
+                    "DeployAccount transaction was sent.",
+                    f"Transaction hash: 0x{response.transaction_hash:064x}",
+                ]
+            )
+        )
+
+
+class AutoEstimateMaxFeeException(ProtostarException):
+    def __init__(self):
+        super().__init__(
+            "Protostar can't auto-estimate max fee for the DeployAccount transaction.\n"
+            "Please provide explicit value."
+        )

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -20,7 +20,7 @@ from protostar.starknet_gateway.gateway_response import SuccessfulDeployAccountR
 
 @dataclass
 class DeployAccountCommandArgs(NetworkArgs):
-    account_address: str
+    account_address: int
     account_address_salt: int
     account_constructor_input: Optional[list[int]]
     account_class_hash: ClassHash
@@ -126,7 +126,7 @@ class DeployAccountCommand(ProtostarCommand):
         if typed_args.max_fee == "auto":
             raise AutoEstimateMaxFeeException()
         return DeployAccountArgs(
-            account_address=int(typed_args.account_address, base=0),
+            account_address=typed_args.account_address,
             account_class_hash=typed_args.account_class_hash,
             account_address_salt=typed_args.account_address_salt,
             nonce=typed_args.nonce,

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -1,0 +1,75 @@
+from argparse import Namespace
+from dataclasses import dataclass
+from logging import Logger
+from typing import Optional
+
+from protostar.cli import ProtostarArgument, ProtostarCommand
+from protostar.cli.network_command_util import NetworkCommandUtil
+from protostar.starknet_gateway import GatewayFacadeFactory
+from protostar.starknet_gateway.gateway_facade import DeployAccountArgs
+from protostar.starknet_gateway.gateway_response import SuccessfulDeployAccountResponse
+
+
+@dataclass
+class DeployAccountCommandArgs:
+    @classmethod
+    def from_args(cls, args: Namespace):
+        cls()
+
+
+class DeployAccountCommand(ProtostarCommand):
+    def __init__(
+        self,
+        logger: Logger,
+        gateway_facade_factory: GatewayFacadeFactory,
+    ) -> None:
+        self._logger = logger
+        self._gateway_facade_factory = gateway_facade_factory
+
+    @property
+    def name(self) -> str:
+        return "deploy"
+
+    @property
+    def description(self) -> str:
+        return "Deploy contracts."
+
+    @property
+    def example(self) -> Optional[str]:
+        return None
+
+    @property
+    def arguments(self):
+        return [
+            *NetworkCommandUtil.network_arguments,
+        ]
+
+    async def run(self, args: Namespace):
+        typed_args = DeployAccountCommandArgs.from_args(args)
+        if self._validate_cli_args(typed_args):
+            deploy_account_args = self._map_typed_args_to_deploy_account_args(
+                typed_args
+            )
+            response = await self._send_deploy_account_tx(deploy_account_args)
+            self._log_response(response)
+
+    def _validate_cli_args(self, typed_args: DeployAccountCommandArgs) -> bool:
+        return True
+
+    def _map_typed_args_to_deploy_account_args(
+        self, typed_args: DeployAccountCommandArgs
+    ) -> DeployAccountArgs:
+        return DeployAccountArgs()
+
+    async def _send_deploy_account_tx(
+        self,
+        typed_args: DeployAccountCommandArgs,
+        deploy_account_args: DeployAccountArgs,
+    ):
+        gateway_facade = self._gateway_facade_factory.create(
+            gateway_client=typed_args.gateway_client, logger=None
+        )
+        return await gateway_facade.deploy_account()
+
+    async def _log_response(self, response: SuccessfulDeployAccountResponse):
+        pass

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -5,7 +5,12 @@ from typing import Optional
 
 from starknet_py.net.signer import BaseSigner
 
-from protostar.cli import NetworkCommandUtil, ProtostarCommand, SignableCommandUtil
+from protostar.cli import (
+    NetworkCommandUtil,
+    ProtostarArgument,
+    ProtostarCommand,
+    SignableCommandUtil,
+)
 from protostar.cli.network_command_util import NetworkArgs
 from protostar.protostar_exception import ProtostarException
 from protostar.starknet_gateway import GatewayFacadeFactory
@@ -16,7 +21,7 @@ from protostar.starknet_gateway.gateway_response import SuccessfulDeployAccountR
 @dataclass
 class DeployAccountCommandArgs(NetworkArgs):
     account_address: str
-    salt: int
+    account_address_salt: int
     account_constructor_input: Optional[list[int]]
     account_class_hash: ClassHash
     nonce: int
@@ -39,7 +44,7 @@ class DeployAccountCommandArgs(NetworkArgs):
             nonce=args.nonce,
             account_class_hash=args.account_class_hash,
             account_constructor_input=args.account_constructor_input or [],
-            salt=args.salt,
+            account_address_salt=args.account_address_salt,
             signer=signer,
             max_fee=args.max_fee,
             gateway_client=gateway_client,
@@ -73,6 +78,36 @@ class DeployAccountCommand(ProtostarCommand):
         return [
             *NetworkCommandUtil.network_arguments,
             *SignableCommandUtil.signable_arguments,
+            ProtostarArgument(
+                name="nonce",
+                description="Protects against the replay attacks.",
+                type="int",
+                default=0,
+            ),
+            ProtostarArgument(
+                name="account-class-hash",
+                description="Class hash of the declared account contract.",
+                type="class_hash",
+                is_required=True,
+            ),
+            ProtostarArgument(
+                name="max-fee",
+                description="Max amount of Wei you are willing to pay for the transaction",
+                type="wei",
+                is_required=True,
+            ),
+            ProtostarArgument(
+                name="account-address-salt",
+                description="This value is expected by account's `__validate_deploy__` entry point",
+                type="int",
+                is_required=True,
+            ),
+            ProtostarArgument(
+                name="account-constructor-input",
+                description="Input to the account's constructor",
+                type="int",
+                is_array=True,
+            ),
         ]
 
     async def run(self, args: Namespace):
@@ -95,7 +130,7 @@ class DeployAccountCommand(ProtostarCommand):
         return DeployAccountArgs(
             account_address=int(typed_args.account_address, base=0),
             account_class_hash=typed_args.account_class_hash,
-            account_address_salt=typed_args.salt,
+            account_address_salt=typed_args.account_address_salt,
             nonce=typed_args.nonce,
             signer=typed_args.signer,
             account_constructor_input=typed_args.account_constructor_input,

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -77,7 +77,6 @@ class DeployAccountCommand(ProtostarCommand):
 
     async def run(self, args: Namespace):
         typed_args = DeployAccountCommandArgs.from_args(args)
-        self._validate_cli_args(typed_args)
         deploy_account_args = self._map_typed_args_to_deploy_account_args(typed_args)
         response = await self._send_deploy_account_tx(
             deploy_account_args=deploy_account_args, typed_args=typed_args
@@ -85,16 +84,14 @@ class DeployAccountCommand(ProtostarCommand):
         self._log_response(response)
         return response
 
-    def _validate_cli_args(self, typed_args: DeployAccountCommandArgs):
-        if typed_args.max_fee == "auto":
-            raise ProtostarException(
-                "Protostar can't auto-estimate max fee for the DeployAccount transaction."
-            )
-
     def _map_typed_args_to_deploy_account_args(
         self,
         typed_args: DeployAccountCommandArgs,
     ) -> DeployAccountArgs:
+        if typed_args.max_fee == "auto":
+            raise ProtostarException(
+                "Protostar can't auto-estimate max fee for the DeployAccount transaction."
+            )
         return DeployAccountArgs(
             account_address=int(typed_args.account_address, base=0),
             account_class_hash=typed_args.account_class_hash,
@@ -102,7 +99,7 @@ class DeployAccountCommand(ProtostarCommand):
             nonce=typed_args.nonce,
             signer=typed_args.signer,
             account_constructor_input=typed_args.account_constructor_input,
-            max_fee=1,
+            max_fee=typed_args.max_fee,
         )
 
     async def _send_deploy_account_tx(

--- a/protostar/commands/deploy_account_command.py
+++ b/protostar/commands/deploy_account_command.py
@@ -124,9 +124,7 @@ class DeployAccountCommand(ProtostarCommand):
         typed_args: DeployAccountCommandArgs,
     ) -> DeployAccountArgs:
         if typed_args.max_fee == "auto":
-            raise ProtostarException(
-                "Protostar can't auto-estimate max fee for the DeployAccount transaction."
-            )
+            raise AutoEstimateMaxFeeException()
         return DeployAccountArgs(
             account_address=int(typed_args.account_address, base=0),
             account_class_hash=typed_args.account_class_hash,
@@ -162,6 +160,6 @@ class DeployAccountCommand(ProtostarCommand):
 class AutoEstimateMaxFeeException(ProtostarException):
     def __init__(self):
         super().__init__(
-            "Protostar can't auto-estimate max fee for the DeployAccount transaction.\n"
-            "Please provide explicit value."
+            "Protostar cannot estimate max fee for the DeployAccount transaction.\n"
+            "Please provide an explicit value."
         )

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -10,6 +10,7 @@ from protostar.commands import (
     BuildCommand,
     CallCommand,
     DeclareCommand,
+    DeployAccountCommand,
     DeployCommand,
     FormatCommand,
     InitCommand,
@@ -184,6 +185,9 @@ def build_di_container(
         CairoMigrateCommand(script_root, logger),
         InvokeCommand(gateway_facade_factory=gateway_facade_factory, logger=logger),
         CallCommand(gateway_facade_factory=gateway_facade_factory, logger=logger),
+        DeployAccountCommand(
+            gateway_facade_factory=gateway_facade_factory, logger=logger
+        ),
     ]
 
     protostar_cli = ProtostarCLI(

--- a/tests/_conftest/devnet/devnet_fixture.py
+++ b/tests/_conftest/devnet/devnet_fixture.py
@@ -12,6 +12,7 @@ class DevnetFixture:
         devnet_gateway_url: str,
         devnet_account_preparator: DevnetAccountPreparator,
     ) -> None:
+        self._devnet_gateway_url = devnet_gateway_url
         self._gateway_client = GatewayClient(devnet_gateway_url)
         self._devnet_account_preparator = devnet_account_preparator
 
@@ -25,3 +26,6 @@ class DevnetFixture:
             transaction_hash, wait_for_accept=True
         )
         assert transaction_status == TransactionStatus.ACCEPTED_ON_L2
+
+    def get_gateway_url(self) -> str:
+        return self._devnet_gateway_url

--- a/tests/e2e/test_gateway_commands.py
+++ b/tests/e2e/test_gateway_commands.py
@@ -141,5 +141,12 @@ def test_invoke_command_is_available(protostar: ProtostarFixture):
     )
 
 
+@pytest.mark.usefixtures("init")
+def test_deploy_account_is_available(protostar: ProtostarFixture):
+    assert "Sends deploy-account transaction" in protostar(
+        ["--no-color", "deploy-account", "--help"]
+    )
+
+
 def count_hex64(x: str) -> int:
     return len(re.findall(r"0x[0-9a-f]{64}", x))

--- a/tests/integration/commands/deploy_account_command_test.py
+++ b/tests/integration/commands/deploy_account_command_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from tests._conftest.devnet import DevnetFixture
+from tests.integration.conftest import CreateProtostarProjectFixture
+from tests.integration.protostar_fixture import ProtostarFixture
+
+
+@pytest.fixture(name="protostar")
+def protostar_fixture(create_protostar_project: CreateProtostarProjectFixture):
+    with create_protostar_project() as protostar:
+        yield protostar
+
+
+async def test_deploying_account(protostar: ProtostarFixture, devnet: DevnetFixture):
+    salt = 1
+    account = await devnet.prepare_account(private_key=123, salt=salt)
+
+    response = await protostar.deploy_account(
+        account_address=account.address,
+        account_address_salt=salt,
+        account_class_hash=account.class_hash,
+        account_constructor_input=[int(account.public_key)],
+        max_fee=1e16,
+        signer=account.signer,
+        nonce=0,
+    )
+    tx = protostar.get_intercepted_transactions_map().deploy_account_txs[0]
+
+    assert tx.class_hash == account.class_hash
+    assert tx.contract_address_salt == salt
+    await devnet.assert_transaction_accepted(response.transaction_hash)

--- a/tests/integration/commands/deploy_account_command_test.py
+++ b/tests/integration/commands/deploy_account_command_test.py
@@ -18,14 +18,14 @@ async def test_deploying_account(
     set_private_key_env_var: SetPrivateKeyEnvVarFixture,
 ):
     salt = 1
-    account = await devnet.prepare_account(private_key=123, salt=salt)
-    with set_private_key_env_var(account.private_key):
+    account = await devnet.prepare_account(private_key=int("0x123", base=16), salt=salt)
+    with set_private_key_env_var("0x123"):
 
         response = await protostar.deploy_account(
             account_address=account.address,
             account_address_salt=salt,
             account_class_hash=account.class_hash,
-            account_constructor_input=[int(account.public_key, 0)],
+            account_constructor_input=[int(account.public_key)],
             max_fee=int(1e16),
             nonce=0,
             gateway_url=devnet.get_gateway_url(),

--- a/tests/integration/commands/deploy_account_command_test.py
+++ b/tests/integration/commands/deploy_account_command_test.py
@@ -24,7 +24,7 @@ async def test_deploying_account(protostar: ProtostarFixture, devnet: DevnetFixt
         signer=account.signer,
         nonce=0,
     )
-    tx = protostar.get_intercepted_transactions_map().deploy_account_txs[0]
+    tx = protostar.get_intercepted_transactions_mapping().deploy_account_txs[0]
 
     assert tx.class_hash == account.class_hash
     assert tx.contract_address_salt == salt

--- a/tests/integration/commands/invoke_command_test.py
+++ b/tests/integration/commands/invoke_command_test.py
@@ -38,9 +38,7 @@ async def test_invoke(
         )
 
         await assert_transaction_accepted(devnet_gateway_url, response.transaction_hash)
-    transaction = protostar.get_intercepted_transaction(
-        index=1, expected_tx_type="invoke"
-    )
+    transaction = protostar.get_intercepted_transactions_mapping().invoke_txs[0]
     assert transaction.max_fee != "auto"
     assert transaction.calldata[6] == 42
     assert transaction.version == 1

--- a/tests/integration/gateway/gateway_facade_test.py
+++ b/tests/integration/gateway/gateway_facade_test.py
@@ -263,7 +263,7 @@ async def test_deploy_account(
 
     response = await gateway_facade.deploy_account(deploy_account_args)
 
-    tx = transaction_registry.get_intercepted_account_transaction(index=0)
+    tx = transaction_registry.deploy_account_txs[0]
     assert tx.class_hash == deploy_account_args.account_class_hash
     assert tx.contract_address_salt == deploy_account_args.account_address_salt
     await devnet.assert_transaction_accepted(response.transaction_hash)

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -123,6 +123,44 @@ An optional salt controlling where the contract will be deployed. The contract d
 Used by whitelisted users for deploying contracts in Alpha MainNet.
 #### `--wait-for-acceptance`
 Waits for transaction to be accepted on chain.
+### `deploy-account`
+Sends deploy-account transaction. The account contract must be already declared and prefunded.
+#### `--account-address STRING`
+Account address
+#### `--account-address-salt INT`
+Required.
+
+This value is expected by account's `__validate_deploy__` entry point
+#### `--account-class-hash CLASS_HASH`
+Required.
+
+Class hash of the declared account contract.
+#### `--account-constructor-input INT[]`
+Input to the account's constructor
+#### `--chain-id INT`
+The chain id. It is required unless `--network` is provided.
+#### `--gateway-url STRING`
+The URL of a StarkNet gateway. It is required unless `--network` is provided.
+#### `--max-fee WEI`
+Required.
+
+Max amount of Wei you are willing to pay for the transaction
+#### `-n` `--network STRING`
+The name of the StarkNet network.
+It is required unless `--gateway-url` is provided.
+
+Supported StarkNet networks:
+- `testnet`
+- `mainnet`
+- `alpha-goerli`
+- `alpha-mainnet`
+#### `--nonce INT`
+Protects against the replay attacks.
+#### `--private-key-path PATH`
+Path to the file, which stores your private key (in hex representation) for the account. 
+Can be used instead of PROTOSTAR_ACCOUNT_PRIVATE_KEY env variable.
+#### `--signer-class STRING`
+Custom signer class module path.
 ### `format`
 ```shell
 $ protostar format

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -67,7 +67,7 @@ Required.
 
 Path to compiled contract.
 #### `--account-address ADDRESS`
-Account address
+Account address.
 #### `--chain-id INT`
 The chain id. It is required unless `--network` is provided.
 #### `--gateway-url STRING`
@@ -125,8 +125,8 @@ Used by whitelisted users for deploying contracts in Alpha MainNet.
 Waits for transaction to be accepted on chain.
 ### `deploy-account`
 Sends deploy-account transaction. The account contract must be already declared and prefunded.
-#### `--account-address STRING`
-Account address
+#### `--account-address ADDRESS`
+Account address.
 #### `--account-address-salt INT`
 Required.
 
@@ -203,7 +203,7 @@ A custom package name. Use it to resolve name conflicts.
 ### `invoke`
 Sends an invoke transaction to the StarkNet sequencer.
 #### `--account-address ADDRESS`
-Account address
+Account address.
 #### `--chain-id INT`
 The chain id. It is required unless `--network` is provided.
 #### `--contract-address ADDRESS`
@@ -243,7 +243,7 @@ Required.
 
 Path to the migration file.
 #### `--account-address ADDRESS`
-Account address
+Account address.
 #### `--chain-id INT`
 The chain id. It is required unless `--network` is provided.
 #### `--compiled-contracts-dir PATH=build`


### PR DESCRIPTION
Allow sending "deploy account" transactions from the CLI.

Related #962. Docs will be added in another PR. 