### PR TITLE
Remove legacy network names

### DIFF
--- a/protostar/cli/network_command_util.py
+++ b/protostar/cli/network_command_util.py
@@ -7,7 +7,7 @@ from starknet_py.net.models import StarknetChainId
 
 from protostar.protostar_exception import ProtostarException
 from protostar.starknet_gateway import NetworkConfig
-from protostar.starknet_gateway.network_config import NETWORKS, is_legacy_network_name
+from protostar.starknet_gateway.network_config import NETWORKS
 
 from .protostar_argument import ProtostarArgument
 
@@ -60,12 +60,6 @@ class NetworkCommandUtil:
         if self._args.network is None and self._args.gateway_url is None:
             raise ProtostarException(
                 f"Argument `{GATEWAY_URL_ARG_NAME}` or `{NETWORK_ARG_NAME}` is required"
-            )
-
-        # TODO(arcticae): Remove in the future version, with the legacy names formats support
-        if self._args.network and is_legacy_network_name(self._args.network):
-            self._logger.warning(
-                f"{self._args.network} is a legacy network name parameter and it won't be supported in future versions"
             )
 
         if self._args.gateway_url and not self._args.chain_id:

--- a/protostar/cli/network_command_util_test.py
+++ b/protostar/cli/network_command_util_test.py
@@ -41,8 +41,6 @@ def create_network_command_util_fixture(
     (
         ("testnet", "https://alpha4.starknet.io"),
         ("mainnet", "https://alpha-mainnet.starknet.io"),
-        ("alpha-goerli", "https://alpha4.starknet.io"),
-        ("alpha-mainnet", "https://alpha-mainnet.starknet.io"),
     ),
 )
 def test_network_config_from_literal(

--- a/protostar/commands/deploy_command.py
+++ b/protostar/commands/deploy_command.py
@@ -36,7 +36,7 @@ class DeployCommand(ProtostarCommand):
 
     @property
     def example(self) -> Optional[str]:
-        return "protostar deploy ./build/main.json --network alpha-goerli"
+        return "protostar deploy ./build/main.json --network testnet"
 
     @property
     def arguments(self):

--- a/protostar/starknet_gateway/network_config_test.py
+++ b/protostar/starknet_gateway/network_config_test.py
@@ -4,13 +4,6 @@ from protostar.starknet_gateway.network_config import NetworkConfig
 def test_loading_starkware_networks():
     assert NetworkConfig.from_starknet_network_name("testnet").gateway_url is not None
     assert NetworkConfig.from_starknet_network_name("mainnet").gateway_url is not None
-    assert (
-        NetworkConfig.from_starknet_network_name("alpha-goerli").gateway_url is not None
-    )
-    assert (
-        NetworkConfig.from_starknet_network_name("alpha-mainnet").gateway_url
-        is not None
-    )
 
 
 def test_testnet_block_explorer():
@@ -18,11 +11,5 @@ def test_testnet_block_explorer():
         NetworkConfig.from_starknet_network_name("testnet").get_contract_explorer_url(
             999
         )
-        == "https://goerli.voyager.online/contract/0x00000000000000000000000000000000000000000000000000000000000003e7"
-    )
-    assert (
-        NetworkConfig.from_starknet_network_name(
-            "alpha-goerli"
-        ).get_contract_explorer_url(999)
         == "https://goerli.voyager.online/contract/0x00000000000000000000000000000000000000000000000000000000000003e7"
     )

--- a/website/docs/cli-reference.md
+++ b/website/docs/cli-reference.md
@@ -45,8 +45,6 @@ It is required unless `--gateway-url` is provided.
 Supported StarkNet networks:
 - `testnet`
 - `mainnet`
-- `alpha-goerli`
-- `alpha-mainnet`
 ### `declare`
 Sends a declare transaction to StarkNet.
 #### `contract PATH`
@@ -68,8 +66,6 @@ It is required unless `--gateway-url` is provided.
 Supported StarkNet networks:
 - `testnet`
 - `mainnet`
-- `alpha-goerli`
-- `alpha-mainnet`
 #### `--private-key-path PATH`
 Path to the file, which stores your private key (in hex representation) for the account. 
 Can be used instead of PROTOSTAR_ACCOUNT_PRIVATE_KEY env variable.
@@ -81,7 +77,7 @@ Used for declaring contracts in Alpha MainNet.
 Waits for transaction to be accepted on chain.
 ### `deploy`
 ```shell
-protostar deploy ./build/main.json --network alpha-goerli
+protostar deploy ./build/main.json --network testnet
 ```
 Deploy contracts.
 #### `contract PATH`
@@ -102,8 +98,6 @@ It is required unless `--gateway-url` is provided.
 Supported StarkNet networks:
 - `testnet`
 - `mainnet`
-- `alpha-goerli`
-- `alpha-mainnet`
 #### `--salt FELT`
 An optional salt controlling where the contract will be deployed. The contract deployment address is determined by the hash of contract, salt and caller. If the salt is not supplied, the contract will be deployed with a random salt.
 #### `--token STRING`
@@ -139,8 +133,6 @@ It is required unless `--gateway-url` is provided.
 Supported StarkNet networks:
 - `testnet`
 - `mainnet`
-- `alpha-goerli`
-- `alpha-mainnet`
 #### `--nonce INT`
 Protects against the replay attacks.
 #### `--private-key-path PATH`
@@ -214,8 +206,6 @@ It is required unless `--gateway-url` is provided.
 Supported StarkNet networks:
 - `testnet`
 - `mainnet`
-- `alpha-goerli`
-- `alpha-mainnet`
 #### `--private-key-path PATH`
 Path to the file, which stores your private key (in hex representation) for the account. 
 Can be used instead of PROTOSTAR_ACCOUNT_PRIVATE_KEY env variable.
@@ -244,8 +234,6 @@ It is required unless `--gateway-url` is provided.
 Supported StarkNet networks:
 - `testnet`
 - `mainnet`
-- `alpha-goerli`
-- `alpha-mainnet`
 #### `--no-confirm`
 Skip confirming building the project.
 #### `--private-key-path PATH`


### PR DESCRIPTION
Remove already deprecated names like `alpha-goerli` to make the block explorer links creator simpler (https://github.com/software-mansion/protostar/pull/1122).