### PR TITLE
Remove unnecessary execution time logs from documentation

### DIFF
--- a/website/docs/tutorials/07-testing/03-fuzzing/README.md
+++ b/website/docs/tutorials/07-testing/03-fuzzing/README.md
@@ -108,7 +108,6 @@ So far, so good. Running the test, we see it passes:
 12:14:51 [INFO] Test suites: 1 passed, 1 total
 12:14:51 [INFO] Tests:       1 passed, 1 total
 12:14:51 [INFO] Seed:        2917010406
-12:14:51 [INFO] Execution time: 5.34 s
 ```
 
 ### Generalizing the test
@@ -199,7 +198,6 @@ amount = 10001
 12:24:06 [INFO] Test suites: 1 failed, 1 total
 12:24:06 [INFO] Tests:       1 failed, 1 total
 12:24:06 [INFO] Seed:        2965326707
-12:24:06 [INFO] Execution time: 11.95 s
 ```
 
 We need to take the `Cannot withdraw more than stored` error into consideration, so we also add a
@@ -245,7 +243,6 @@ amount = 36185027886661312136973227830950701056231072153315966999730920561358720
 12:25:29 [INFO] Test suites: 1 failed, 1 total
 12:25:29 [INFO] Tests:       1 failed, 1 total
 12:25:29 [INFO] Seed:        1746010604
-12:25:29 [INFO] Execution time: 7.34 s
 ```
 
 ### Fixing the bug
@@ -286,7 +283,6 @@ contract code.
 12:27:35 [INFO] Test suites: 1 passed, 1 total
 12:27:35 [INFO] Tests:       1 passed, 1 total
 12:27:35 [INFO] Seed:        3287645654
-12:27:35 [INFO] Execution time: 13.46 s
 ```
 
 ## Interpreting results

--- a/website/docs/tutorials/08-interacting-with-starknet/01-invoke.md
+++ b/website/docs/tutorials/08-interacting-with-starknet/01-invoke.md
@@ -28,7 +28,6 @@ Custom signing logic is made possible by using custom signers - see details [her
 protostar invoke --contract-address 0x4a739ab73aa3cac01f9da5d55f49fb67baee4919224454a2e3f85b16462a911 --function "setter_tester_success" --network testnet --account-address 0x0481Eed2e02b1ff19Fd32429801f28a59DEa630d81189E39c80F2F60139b381a --max-fee auto --inputs 3 --private-key-path ./.pkey
 16:54:56 [INFO] Invoke transaction was sent.
 Transaction hash: 0x05d2362b9b5a5aba8a02a41d2f1fcbdc06cde89f90cf33c0ea4957846c86aeef
-16:54:57 [INFO] Execution time: 13.17 s
 ```
 :::warning
 Setting `max-fee` to `auto` is discouraged, since it may incur extra unexpected costs.

--- a/website/docs/tutorials/08-interacting-with-starknet/02-call.md
+++ b/website/docs/tutorials/08-interacting-with-starknet/02-call.md
@@ -23,7 +23,6 @@ Response:
 {
     "res": 6
 }
-15:07:35 [INFO] Execution time: 2.20 s
 ```
 
 :::note


### PR DESCRIPTION
commit-id:6d2060cc

---

**Stack**:
- #1132
- #1137
- #1134
- #1131
- #1136
- #1135 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*