### PR TITLE
Allow E2E testing without stderr, and do not emit empty lines by disa…

### DIFF
--- a/binary_entrypoint.py
+++ b/binary_entrypoint.py
@@ -60,13 +60,13 @@ class ProtostarInitializingIndicator:
         self._disabled = disabled
 
     def start(self):
+        if self._disabled:
+            return
+
         self._thread.start()
         return self
 
     def _animate(self):
-        if self._disabled:
-            return
-
         for step in cycle(self.steps):
             if self.done:
                 break
@@ -74,6 +74,9 @@ class ProtostarInitializingIndicator:
             sleep(self.interval)
 
     def stop(self):
+        if self._disabled:
+            return
+
         self.done = True
         cols = get_terminal_size((80, 20)).columns
         print("\r" + " " * cols, end="\r", flush=True)

--- a/protostar/cli/activity_indicator.py
+++ b/protostar/cli/activity_indicator.py
@@ -32,9 +32,10 @@ class ActivityIndicator:
             sleep(self.interval)
 
     def stop(self):
-        self.done = True
-        cols = get_terminal_size((80, 20)).columns
-        print("\r" + " " * cols, end="\r", flush=True)
+        if is_terminal():
+            self.done = True
+            cols = get_terminal_size((80, 20)).columns
+            print("\r" + " " * cols, end="\r", flush=True)
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
…bled activity indicators

commit-id:25c2df9c

---

**Stack**:
- #1132
- #1137
- #1134
- #1131
- #1136 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*