### PR TITLE
Remove max returns

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -567,9 +567,6 @@ max-parents=7
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
-# Maximum number of return / yield for function / method body.
-max-returns=6
-
 # Maximum number of statements in function / method body.
 max-statements=50
 


### PR DESCRIPTION
As requested [here](https://github.com/software-mansion/protostar/pull/1140#discussion_r1021324991), I'm moving this to a new PR.

We decided that the lint rule `max-returns` is not that good and can be removed.