### PR TITLE
Fix kebab-case with positional arguments

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -94,6 +94,7 @@ disable=fixme,
         too-many-arguments,
         too-many-locals,
         invalid-name,
+        no-member
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/protostar/argument_parser/argument_parser_facade.py
+++ b/protostar/argument_parser/argument_parser_facade.py
@@ -60,6 +60,7 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
         else:
             args = self.argument_parser.parse_args(input_args)
 
+        args = self._replace_dashes_with_underscores(args)
         missing_data = self._find_missing_required_arg_in_project(args)
         if missing_data:
             (command, arg) = missing_data
@@ -71,6 +72,12 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
 
     def print_help(self):
         self.argument_parser.print_help()
+
+    def _replace_dashes_with_underscores(self, args: Namespace) -> Namespace:
+        new_args = Namespace()
+        for key, value in vars(args).items():
+            setattr(new_args, key.replace("-", "_"), value)
+        return new_args
 
     def _find_missing_required_arg_in_project(
         self, parsed_args: Namespace

--- a/protostar/argument_parser/argument_parser_facade_test.py
+++ b/protostar/argument_parser/argument_parser_facade_test.py
@@ -226,3 +226,51 @@ def test_loading_required_value_from_provider():
     result = parser.parse(["fake-cmd"])
 
     assert result.fake_arg == fake_value
+
+
+def create_fake_command(args: list[Argument]):
+    class FakeCommand(Command):
+        @property
+        def name(self) -> str:
+            return "fake-cmd"
+
+        @property
+        def description(self) -> str:
+            return "..."
+
+        @property
+        def example(self) -> Optional[str]:
+            return None
+
+        @property
+        def arguments(self) -> List[Argument]:
+            return args
+
+        async def run(self, args: Any):
+            return await super().run(args)
+
+    return FakeCommand()
+
+
+def test_kebab_case_with_positional_arguments():
+    app = CLIApp(
+        root_args=[],
+        commands=[
+            create_fake_command(
+                [
+                    Argument(
+                        name="kebab-case",
+                        description="...",
+                        type="str",
+                        is_required=True,
+                        is_positional=True,
+                    )
+                ]
+            )
+        ],
+    )
+    parser = ArgumentParserFacade(app)
+
+    args = parser.parse(["fake-cmd", "value"])
+
+    assert args.kebab_case == "value"


### PR DESCRIPTION
Replace dashes with underscores in the parsing result. Argparse doesn't do that for some reason. Disabled pylint's no-member rule due to false positives.

https://bugs.python.org/issue15125

Related https://github.com/software-mansion/protostar/pull/1168