### PR TITLE
Fix parsing non-string values from configuration file

### DIFF
--- a/protostar/argument_parser/arg_type.py
+++ b/protostar/argument_parser/arg_type.py
@@ -16,7 +16,7 @@ ArgTypeName = Literal[
 def map_type_name_to_parser(argument_type: ArgTypeName) -> Callable[[str], Any]:
     type_name_to_parser_mapping: dict[ArgTypeName, Callable[[str], Any]] = {
         "str": str,
-        "bool": bool,
+        "bool": parse_bool_arg_type,
         "int": int,
         "directory": parse_directory_arg_type,
         "regexp": re.compile,
@@ -25,6 +25,12 @@ def map_type_name_to_parser(argument_type: ArgTypeName) -> Callable[[str], Any]:
     if argument_type in type_name_to_parser_mapping:
         return type_name_to_parser_mapping[argument_type]
     assert False, f"Unknown argument type {argument_type}"
+
+
+def parse_bool_arg_type(arg: str) -> bool:
+    if arg in ["false", "False", "0"]:
+        return False
+    return bool(arg)
 
 
 def parse_directory_arg_type(arg: str) -> Path:

--- a/protostar/argument_parser/arg_type_test.py
+++ b/protostar/argument_parser/arg_type_test.py
@@ -38,3 +38,18 @@ def test_regex_arg_type():
     result = map_type_name_to_parser("regexp")(".*")
 
     assert isinstance(result, Pattern)
+
+
+@pytest.mark.parametrize(
+    "input_data, result",
+    [
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+    ],
+)
+def test_bool_arg_type(input_data: str, result: bool):
+    assert map_type_name_to_parser("bool")(input_data) == result

--- a/protostar/argument_parser/argument.py
+++ b/protostar/argument_parser/argument.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, replace
-from typing import Any, Generic, Optional, TypeVar, Dict
+from typing import Any, Generic, Optional, TypeVar
+
+from typing_extensions import Self
 
 ArgTypeNameT = TypeVar("ArgTypeNameT")
 
@@ -16,5 +18,5 @@ class Argument(Generic[ArgTypeNameT]):
     example: Optional[str] = None
     short_name: Optional[str] = None
 
-    def copy_with(self, **changes: Dict[str, Any]) -> "Argument":
+    def copy_with(self, **changes: Any) -> Self:
         return replace(self, **changes)

--- a/protostar/argument_parser/argument_parser_facade.py
+++ b/protostar/argument_parser/argument_parser_facade.py
@@ -11,8 +11,6 @@ from typing import (
     TypeVar,
 )
 
-from protostar.argument_parser.unparser import unparse_flag_or_arguments
-
 from .arg_type import ArgTypeName, map_type_name_to_parser
 from .argument import Argument
 from .cli_app import CLIApp
@@ -156,11 +154,10 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
         self, command: Optional[Command], argument: Argument[ArgTypeNameT_contra]
     ) -> Argument[ArgTypeNameT_contra]:
         if self._config_file_argument_value_resolver:
-            new_default = unparse_flag_or_arguments(
-                self._config_file_argument_value_resolver.resolve_argument(
-                    command.name if command else None, argument.name
-                )
+            new_default = self._config_file_argument_value_resolver.resolve_argument(
+                command.name if command else None, argument.name
             )
+
             if new_default is not None:
                 return argument.copy_with(default=new_default)
         return argument
@@ -188,7 +185,7 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
             )
             return argument_parser
 
-        arg_type = self._parser_resolver(argument.type)
+        parse_arg = self._parser_resolver(argument.type)
 
         default = argument.default
 
@@ -205,7 +202,7 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
 
         argument_parser.add_argument(
             *names,
-            type=arg_type,
+            type=parse_arg,
             default=default,
             help=argument.description,
             **kwargs,

--- a/protostar/argument_parser/argument_parser_facade.py
+++ b/protostar/argument_parser/argument_parser_facade.py
@@ -11,6 +11,8 @@ from typing import (
     TypeVar,
 )
 
+from protostar.argument_parser.unparser import unparse_flag_or_arguments
+
 from .arg_type import ArgTypeName, map_type_name_to_parser
 from .argument import Argument
 from .cli_app import CLIApp
@@ -132,7 +134,7 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
         for arg in command.arguments:
             self._add_argument(
                 command_parser,
-                self._update_from_config(command, arg),  # type: ignore
+                self._set_value_from_external_source(command, arg),  # type: ignore
             )
 
         return self
@@ -146,16 +148,18 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
 
         self._add_argument(
             self.argument_parser,
-            self._update_from_config(None, argument),
+            self._set_value_from_external_source(None, argument),
         )
         return self
 
-    def _update_from_config(
+    def _set_value_from_external_source(
         self, command: Optional[Command], argument: Argument[ArgTypeNameT_contra]
     ) -> Argument[ArgTypeNameT_contra]:
         if self._config_file_argument_value_resolver:
-            new_default = self._config_file_argument_value_resolver.resolve_argument(
-                command.name if command else None, argument.name
+            new_default = unparse_flag_or_arguments(
+                self._config_file_argument_value_resolver.resolve_argument(
+                    command.name if command else None, argument.name
+                )
             )
             if new_default is not None:
                 return argument.copy_with(default=new_default)

--- a/protostar/argument_parser/argument_parser_facade.py
+++ b/protostar/argument_parser/argument_parser_facade.py
@@ -171,7 +171,7 @@ class ArgumentParserFacade(Generic[ArgTypeNameT_contra]):
             new_default = parsed_values
             if not argument.is_array:
                 new_default = parsed_values[0] if len(parsed_values) > 0 else None
-            return argument.copy_with(default=new_default)  # type: ignore
+            return argument.copy_with(default=new_default)
         return argument
 
     def _add_argument(

--- a/protostar/argument_parser/argument_parser_facade_test.py
+++ b/protostar/argument_parser/argument_parser_facade_test.py
@@ -281,22 +281,22 @@ def test_kebab_case_with_positional_arguments():
 @pytest.mark.parametrize(
     "value_in_config_file, result",
     [
-        ("string_value", "string_value"),
-        (42, "42"),
-        (["arr", "ray"], "arr ray"),
+        ("21", 21),
+        (37, 37),
+        (["21", "37"], [21, 37]),
     ],
 )
-def test_parsing_extra_arguments_source(value_in_config_file: Any, result: str):
+def test_parsing_extra_arguments_source(value_in_config_file: Any, result: Any):
     parser_called = False
 
-    def fake_parser(arg: str):
+    def parse_to_int(arg: str):
         assert isinstance(arg, str)
         nonlocal parser_called
         parser_called = True
         return arg
 
     def fake_parser_resolver(_argument_type: ArgTypeName):
-        return fake_parser
+        return parse_to_int
 
     parser = ArgumentParserFacade(
         CLIApp(

--- a/protostar/argument_parser/argument_parser_facade_test.py
+++ b/protostar/argument_parser/argument_parser_facade_test.py
@@ -278,7 +278,8 @@ def test_kebab_case_with_positional_arguments():
     assert args.kebab_case == "value"
 
 
-def test_parsing_extra_arguments_source():
+@pytest.mark.parametrize("value_in_config_file", ["string_value", 42])
+def test_parsing_extra_arguments_source(value_in_config_file: Any):
     parser_called = False
 
     def fake_parser(arg: str):
@@ -295,11 +296,12 @@ def test_parsing_extra_arguments_source():
             root_args=[Argument(name="foo", description="", example="", type="str")]
         ),
         config_file_argument_value_resolver=FakeConfigFileArgumentResolver(
-            argument_value="FOOBAR"
+            argument_value=value_in_config_file
         ),
         parser_resolver=fake_parser_resolver,
     )
 
-    parser.parse("")
+    args = parser.parse("")
 
     assert parser_called
+    assert args.foo is not None

--- a/protostar/argument_parser/argument_parser_facade_test.py
+++ b/protostar/argument_parser/argument_parser_facade_test.py
@@ -278,8 +278,15 @@ def test_kebab_case_with_positional_arguments():
     assert args.kebab_case == "value"
 
 
-@pytest.mark.parametrize("value_in_config_file", ["string_value", 42])
-def test_parsing_extra_arguments_source(value_in_config_file: Any):
+@pytest.mark.parametrize(
+    "value_in_config_file, result",
+    [
+        ("string_value", "string_value"),
+        (42, "42"),
+        (["arr", "ray"], "arr ray"),
+    ],
+)
+def test_parsing_extra_arguments_source(value_in_config_file: Any, result: str):
     parser_called = False
 
     def fake_parser(arg: str):
@@ -304,4 +311,4 @@ def test_parsing_extra_arguments_source(value_in_config_file: Any):
     args = parser.parse("")
 
     assert parser_called
-    assert args.foo is not None
+    assert args.foo == result

--- a/protostar/argument_parser/argument_parser_facade_test.py
+++ b/protostar/argument_parser/argument_parser_facade_test.py
@@ -289,18 +289,26 @@ def test_kebab_case_with_positional_arguments():
 def test_parsing_extra_arguments_source(value_in_config_file: Any, result: Any):
     parser_called = False
 
-    def parse_to_int(arg: str):
+    def parse_to_int(arg: str) -> int:
         assert isinstance(arg, str)
         nonlocal parser_called
         parser_called = True
-        return arg
+        return int(arg)
 
     def fake_parser_resolver(_argument_type: ArgTypeName):
         return parse_to_int
 
     parser = ArgumentParserFacade(
         CLIApp(
-            root_args=[Argument(name="foo", description="", example="", type="str")]
+            root_args=[
+                Argument(
+                    name="foo",
+                    description="",
+                    example="",
+                    type="str",
+                    is_array=isinstance(value_in_config_file, list),
+                )
+            ]
         ),
         config_file_argument_value_resolver=FakeConfigFileArgumentResolver(
             argument_value=value_in_config_file

--- a/protostar/argument_parser/conftest.py
+++ b/protostar/argument_parser/conftest.py
@@ -84,3 +84,27 @@ def foo_command_fixture() -> FooCommand:
 @pytest.fixture(name="bar_command")
 def bar_command_fixture() -> BarCommand:
     return BarCommand()
+
+
+def create_fake_command(args: list[Argument]):
+    class FakeCommand(Command):
+        @property
+        def name(self) -> str:
+            return "fake-cmd"
+
+        @property
+        def description(self) -> str:
+            return "..."
+
+        @property
+        def example(self) -> Optional[str]:
+            return None
+
+        @property
+        def arguments(self) -> list[Argument]:
+            return args
+
+        async def run(self, args: Any):
+            return await super().run(args)
+
+    return FakeCommand()

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -3,6 +3,8 @@ from typing import Any
 
 def unparse_flag_or_arguments(value: Any):
     """Arguments from external sources need to be unparsed in order to be parsed by custom parsers."""
+    if value is None:
+        return None
     if isinstance(value, bool):
         return value
     return unparse_arguments(value)

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -21,7 +21,7 @@ def unparse_arguments(value: Any) -> list[str]:
 
 def unparse_single_value(value: Any) -> str:
     if isinstance(value, bool):
-        return str(bool)
+        return "true" if value else "false"
     if isinstance(value, int):
         return str(value)
     if isinstance(value, str):

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -1,24 +1,24 @@
-from typing import Any
+from typing import Any, Optional
 
 
-def unparse_flag_or_arguments(value: Any):
+def unparse_flag_or_arguments(value: Any) -> Optional[list[str]]:
     """Arguments from external sources need to be unparsed in order to be parsed by custom parsers."""
     if value is None:
         return None
     if isinstance(value, bool):
-        return value
+        return None
     return unparse_arguments(value)
 
 
-def unparse_arguments(value: Any) -> str:
+def unparse_arguments(value: Any) -> list[str]:
     if not isinstance(value, list):
-        return unparse_single_value(value)
+        return [unparse_single_value(value)]
 
     values = value
     unparsed_values: list[str] = []
     for val in values:
-        unparsed_values.append(unparse_arguments(val))
-    return " ".join(unparsed_values)
+        unparsed_values.append(*unparse_arguments(val))
+    return unparsed_values
 
 
 def unparse_single_value(value: Any) -> str:

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 
-def unparse_flag_or_arguments(value: Any) -> Optional[list[str]]:
+def unparse_arguments_from_external_source(value: Any) -> Optional[list[str]]:
     """Arguments from external sources need to be unparsed in order to be parsed by custom parsers."""
     if value is None:
         return None

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -5,8 +5,6 @@ def unparse_arguments_from_external_source(value: Any) -> Optional[list[str]]:
     """Arguments from external sources need to be unparsed in order to be parsed by custom parsers."""
     if value is None:
         return None
-    if isinstance(value, bool):
-        return None
     return unparse_arguments(value)
 
 
@@ -22,7 +20,8 @@ def unparse_arguments(value: Any) -> list[str]:
 
 
 def unparse_single_value(value: Any) -> str:
-    assert not isinstance(value, bool)
+    if isinstance(value, bool):
+        return "true" if value else "false"
     if isinstance(value, int):
         return str(value)
     if isinstance(value, str):

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -21,9 +21,9 @@ def unparse_arguments(value: Any) -> list[str]:
 
 def unparse_single_value(value: Any) -> str:
     if isinstance(value, bool):
-        return "true" if value else "false"
+        return str(bool)
     if isinstance(value, int):
         return str(value)
     if isinstance(value, str):
         return value
-    assert False, f"Value '{value}' couldn't be unparsed"
+    raise ValueError(f"Value '{value!r}' couldn't be unparsed")

--- a/protostar/argument_parser/unparser.py
+++ b/protostar/argument_parser/unparser.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+
+def unparse_flag_or_arguments(value: Any):
+    """Arguments from external sources need to be unparsed in order to be parsed by custom parsers."""
+    if isinstance(value, bool):
+        return value
+    return unparse_arguments(value)
+
+
+def unparse_arguments(value: Any) -> str:
+    if not isinstance(value, list):
+        return unparse_single_value(value)
+
+    values = value
+    unparsed_values: list[str] = []
+    for val in values:
+        unparsed_values.append(unparse_arguments(val))
+    return " ".join(unparsed_values)
+
+
+def unparse_single_value(value: Any) -> str:
+    assert not isinstance(value, bool)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    assert False, f"Value '{value}' couldn't be unparsed"

--- a/protostar/argument_parser/unparser_test.py
+++ b/protostar/argument_parser/unparser_test.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from .unparser import unparse_flag_or_arguments
+from .unparser import unparse_arguments_from_external_source
 
 
 @pytest.mark.parametrize(
@@ -16,4 +16,4 @@ from .unparser import unparse_flag_or_arguments
     ],
 )
 def test_unparsing_to_cli_representation(value: Any, result: str):
-    assert unparse_flag_or_arguments(value) == result
+    assert unparse_arguments_from_external_source(value) == result

--- a/protostar/argument_parser/unparser_test.py
+++ b/protostar/argument_parser/unparser_test.py
@@ -8,10 +8,11 @@ from .unparser import unparse_flag_or_arguments
 @pytest.mark.parametrize(
     "value, result",
     [
-        ("foo", "foo"),
-        (42, "42"),
-        (True, True),
-        (["foo", "bar"], "foo bar"),
+        ("foo", ["foo"]),
+        (42, ["42"]),
+        (True, None),
+        (["foo", "bar"], ["foo", "bar"]),
+        ([21, 37], ["21", "37"]),
     ],
 )
 def test_unparsing_to_cli_representation(value: Any, result: str):

--- a/protostar/argument_parser/unparser_test.py
+++ b/protostar/argument_parser/unparser_test.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+import pytest
+
+from .unparser import unparse_flag_or_arguments
+
+
+@pytest.mark.parametrize(
+    "value, result",
+    [
+        ("foo", "foo"),
+        (42, "42"),
+        (True, True),
+        (["foo", "bar"], "foo bar"),
+    ],
+)
+def test_unparsing_to_cli_representation(value: Any, result: str):
+    assert unparse_flag_or_arguments(value) == result

--- a/protostar/argument_parser/unparser_test.py
+++ b/protostar/argument_parser/unparser_test.py
@@ -10,7 +10,8 @@ from .unparser import unparse_arguments_from_external_source
     [
         ("foo", ["foo"]),
         (42, ["42"]),
-        (True, None),
+        (True, ["true"]),
+        (False, ["false"]),
         (["foo", "bar"], ["foo", "bar"]),
         ([21, 37], ["21", "37"]),
     ],


### PR DESCRIPTION
Run type parsers on arguments from configuration file. Argparse runs parsers on default values only if they are strings.

Closes #1178 