### PR TITLE
Allow preparing contract adresses deterministically

### DIFF
--- a/protostar/testing/cheatcodes/prepare_cheatcode.py
+++ b/protostar/testing/cheatcodes/prepare_cheatcode.py
@@ -39,6 +39,7 @@ class PrepareCheatcode(Cheatcode):
         self,
         declared: DeclaredContract,
         constructor_calldata: Optional[CairoOrPythonData] = None,
+        salt: Optional[int] = None,
     ) -> PreparedContract:
         constructor_calldata = constructor_calldata or []
 
@@ -48,12 +49,14 @@ class PrepareCheatcode(Cheatcode):
             )
         contract_salt = PrepareCheatcode.salt_nonce
         PrepareCheatcode.salt_nonce += 1
+        if salt is not None:
+            contract_salt = salt
 
         contract_address = calculate_contract_address_from_hash(
             salt=contract_salt,
             class_hash=declared.class_hash,
             constructor_calldata=constructor_calldata,
-            deployer_address=self.contract_address,
+            deployer_address=0,
         )
 
         self.cheatable_state.contract_address_to_class_hash_map[

--- a/tests/integration/cheatcodes/prepare/prepare_test.cairo
+++ b/tests/integration/cheatcodes/prepare/prepare_test.cairo
@@ -21,3 +21,15 @@ func test_data_transformation{syscall_ptr: felt*, range_check_ptr}() {
 
     return ();
 }
+
+
+@external
+func test_address_can_be_created_deterministically{syscall_ptr: felt*, range_check_ptr}() {
+    %{
+        declaration = declare("./tests/integration/cheatcodes/deploy_contract/basic_with_constructor_uint256.cairo")
+        contract_address = prepare(declaration, { "initial_balance": 42 }, salt=1).contract_address
+        assert contract_address == 2817539553677678999115006446979078392971354750909103470606277416588805704243        
+    %}
+
+    return ();
+}

--- a/tests/integration/cheatcodes/prepare/prepare_test.py
+++ b/tests/integration/cheatcodes/prepare/prepare_test.py
@@ -8,7 +8,7 @@ from tests.integration.conftest import (
 
 async def test_prepare_cheatcode(run_cairo_test_runner: RunCairoTestRunnerFixture):
     testing_summary = await run_cairo_test_runner(
-        Path(__file__).parent / "prepare_test.cairo"
+        Path(__file__).parent / "prepare_test.cairo",
     )
 
     assert_cairo_test_cases(
@@ -16,6 +16,7 @@ async def test_prepare_cheatcode(run_cairo_test_runner: RunCairoTestRunnerFixtur
         expected_passed_test_cases_names=[
             "test_passing_constructor_data_as_list",
             "test_data_transformation",
+            "test_address_can_be_created_deterministically",
         ],
         expected_failed_test_cases_names=[],
     )


### PR DESCRIPTION
Make `prepare` cheatcode accept a salt parameter to allow deterministic contract addresses. 