### PR TITLE
Revert commit "release Protostar 0.9.0" (release failed)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "protostar"
 readme = "README.md"
 repository = "https://github.com/software-mansion/protostar"
-version = "0.9.0"
+version = "0.8.1"
 
 [tool.poetry.dependencies]
 argparse = "^1.4.0"


### PR DESCRIPTION
This reverts commit 26274f79283d671401a2031214710b2e362a3945. https://github.com/software-mansion/protostar/pull/1272 should fix the action.