### PR TITLE
Fix flaky test (`empty_protostar_toml` fixture)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,21 +119,6 @@ def log_color_provider_fixture() -> LogColorProvider:
     return log_color_provider
 
 
-@contextmanager
-def empty_protostar_toml():
-    toml_path = (Path(".") / "protostar.toml").resolve()
-    lib_dir = (Path(".") / "lib").resolve()
-    lib_dir.mkdir(exist_ok=True)
-    with open(toml_path, mode="w+", encoding="utf-8") as file:
-        file.write(
-            """["protostar.project"]\nlibs_path="lib"\n["protostar.contracts"]"""
-        )
-    yield
-    toml_path.unlink(missing_ok=True)
-    if lib_dir.is_dir():
-        lib_dir.rmdir()
-
-
 @pytest.fixture(name="run_cairo_test_runner", scope="module")
 def run_cairo_test_runner_fixture(
     session_mocker: MockerFixture, log_color_provider: LogColorProvider
@@ -171,23 +156,23 @@ def run_cairo_test_runner_fixture(
                 f"{str(path)}::{ignored_test_case}"
                 for ignored_test_case in ignored_test_cases
             ]
-        with empty_protostar_toml():
-            return await TestCommand(
-                project_root_path=Path(),
-                protostar_directory=protostar_directory_mock,
-                project_cairo_path_builder=project_cairo_path_builder,
-                log_color_provider=log_color_provider,
-                active_profile_name=None,
-                cwd=Path(),
-            ).test(
-                targets=targets,
-                ignored_targets=ignored_targets,
-                seed=seed,
-                max_steps=max_steps,
-                profiling=profiling,
-                disable_hint_validation=disable_hint_validation,
-                cairo_path=cairo_path or [],
-            )
+
+        return await TestCommand(
+            project_root_path=Path(),
+            protostar_directory=protostar_directory_mock,
+            project_cairo_path_builder=project_cairo_path_builder,
+            log_color_provider=log_color_provider,
+            active_profile_name=None,
+            cwd=Path(),
+        ).test(
+            targets=targets,
+            ignored_targets=ignored_targets,
+            seed=seed,
+            max_steps=max_steps,
+            profiling=profiling,
+            disable_hint_validation=disable_hint_validation,
+            cairo_path=cairo_path or [],
+        )
 
     return run_cairo_test_runner
 


### PR DESCRIPTION
Removes `empty_protostar_toml` fixture. It created a corrupted file in the project root directory, which was causes nondeterministic failures of CLI reference docs snapshot test. The CLI reference docs test fails, because it uses the `ProtostarCLI` build in the composition root to ensure that documentation matches the CLI. The composition root loads the configuration file because Marek didn't like lazy loading. 

Flaky test example:
https://github.com/software-mansion/protostar/actions/runs/3674857449/jobs/6213618607