### PR TITLE
Prevent using felt pointer for dict

### DIFF
--- a/protostar/starknet/data_transformer.py
+++ b/protostar/starknet/data_transformer.py
@@ -30,6 +30,16 @@ def from_python_transformer(
 
     def transform(data: PythonData) -> CairoData:
         try:
+            for data_item_name, data_item_value in data.items():
+                for item in fn_abi_item[mode]:
+                    if (
+                        data_item_name == item["name"]
+                        and isinstance(data_item_value, dict)
+                        and item["type"] == "felt*"
+                    ):
+                        raise TypeError(
+                            f"invalid type 'dict' for felt* used for argument {data_item_name}"
+                        )
             return structure_transformer.from_python(fn_abi_item[mode], **data)[0]
         except (TypeError, ValueError) as ex:
             raise DataTransformerException(str(ex)) from ex

--- a/tests/integration/data_transformer/contracts.py
+++ b/tests/integration/data_transformer/contracts.py
@@ -34,6 +34,18 @@ func input_outer_struct(arg: OuterStruct) {
 }
 """
 
+DATA_TRANSFORMER_LIST_CONTRACT = """%lang starknet
+from starkware.cairo.common.uint256 import Uint256
+
+@external
+func input_lists(
+        felt_list_len: felt,
+        felt_list: felt*,
+    ) {
+    return ();
+}
+"""
+
 DATA_TRANSFORMER_LISTS_CONTRACT = """%lang starknet
 from starkware.cairo.common.uint256 import Uint256
 

--- a/tests/integration/data_transformer/data_transformer_test.py
+++ b/tests/integration/data_transformer/data_transformer_test.py
@@ -31,6 +31,24 @@ from tests.integration.data_transformer.contracts import (
     "contract,function_name,mode,data",
     [
         [
+            DATA_TRANSFORMER_FELT_CONSTRUCTOR_CONTRACT,
+            "constructor",
+            "inputs",
+            {"arg": 0xD00D00},
+        ],
+        [
+            DATA_TRANSFORMER_UINT256_CONTRACT,
+            "input_uint256",
+            "inputs",
+            {"arg": 1 << 237},
+        ],
+        [
+            DATA_TRANSFORMER_UINT256_CONTRACT,
+            "input_uint256",
+            "inputs",
+            {"arg": {"high": 101, "low": 102}},
+        ],
+        [
             DATA_TRANSFORMER_LISTS_CONTRACT,
             "input_lists",
             "inputs",
@@ -38,6 +56,30 @@ from tests.integration.data_transformer.contracts import (
                 "felt_list": [1, 2, 3, 4, 5],
                 "uint256_list": [1 << 217, {"high": 1, "low": 0x47}, 7],
             },
+        ],
+        [
+            DATA_TRANSFORMER_TUPLE_CONTRACT,
+            "input_tuple",
+            "inputs",
+            {"arg": (535345345, 61231231223)},
+        ],
+        [
+            DATA_TRANSFORMER_STRUCTS_CONTRACT,
+            "input_outer_struct",
+            "inputs",
+            {"arg": {"felt_field": 13, "inner_field": {"a": 0x1, "b": 0x2, "c": 0x3}}},
+        ],
+        [
+            DATA_TRANSFORMER_OUTPUT_FELT_CONTRACT,
+            "output_felt",
+            "outputs",
+            {"res": 3732423423423},
+        ],
+        [
+            DATA_TRANSFORMER_OUTPUT_FELT_CONTRACT,
+            "output_felt",
+            "inputs",
+            {},
         ],
     ],
 )
@@ -364,6 +406,19 @@ def test_data_transformer_to_python(get_abi_from_contract: GetAbiFromContractFix
     assert isinstance(python_data, dict)
     cairo_data2 = from_python(python_data)
     assert cairo_data == cairo_data2
+
+
+def test_uint256_as_2_felts(get_abi_from_contract: GetAbiFromContractFixture):
+    abi = get_abi_from_contract(DATA_TRANSFORMER_UINT256_CONTRACT)
+    from_python = from_python_transformer(abi, "input_uint256", "inputs")
+
+    UINT256_SINGLE = 0x00001000000000000000000000000000_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    UINT256_DICT = {
+        "high": 0x00001000000000000000000000000000,
+        "low": 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+    }
+
+    assert from_python({"arg": UINT256_SINGLE}) == from_python({"arg": UINT256_DICT})
 
 
 def assert_is_int_list(unknown: Any):


### PR DESCRIPTION
The point is to prevent people from using `felt*` for passing `dict`s like this:
```
%{ ids.proxy_contract_address = deploy_contract("./ctr.cairo", {"d": {"a": 1, "b": 3}}).contract_address %}
// ctr.cairo
func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(d_len: felt, d: felt*) {
    %{
        from starkware.cairo.lang.vm.relocatable import RelocatableValue
        rel = RelocatableValue.to_felt_or_relocatable(ids.d)
        values = [memory[rel+i] for i in range(0, ids.d_len)]
        print("length", ids.d_len)
        print("values", values) # that's going to give you only the keys and will cause a data loss
    %}
    return ();
}
```

fix #1266
