### PR TITLE
Hotfix CI freezes — Use `module` scope for devnet fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def run_devnet(devnet: List[str], port: int) -> subprocess.Popen:
     )
 
 
-@pytest.fixture(name="devnet_port", scope="session")
+@pytest.fixture(name="devnet_port", scope="module")
 def devnet_port_fixture() -> int:
     with Socket() as socket:
         socket.bind(("", 0))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -178,7 +178,7 @@ Output:
     return _protostar
 
 
-@pytest.fixture(name="devnet_gateway_url", scope="session")
+@pytest.fixture(name="devnet_gateway_url", scope="module")
 def devnet_gateway_url_fixture(devnet_port: int, protostar_repo_root: Path):
     prev_cwd = getcwd()
     chdir(protostar_repo_root)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,7 +85,7 @@ def assert_cairo_test_cases(
     assert actual == expected
 
 
-@pytest.fixture(name="devnet_gateway_url", scope="session")
+@pytest.fixture(name="devnet_gateway_url", scope="module")
 def devnet_gateway_url_fixture(
     devnet_port: int,
 ):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,7 @@ from protostar.commands.test.test_command import TestCommand
 from protostar.compiler.project_cairo_path_builder import ProjectCairoPathBuilder
 from protostar.io.log_color_provider import LogColorProvider
 from protostar.testing import TestingSummary
-from tests.conftest import run_devnet
+from tests.conftest import TESTS_ROOT_PATH, run_devnet
 from tests.integration.protostar_fixture import (
     ProtostarFixture,
     build_protostar_fixture,
@@ -89,10 +89,13 @@ def assert_cairo_test_cases(
 def devnet_gateway_url_fixture(
     devnet_port: int,
 ):
+    cwd = os.getcwd()
+    os.chdir(TESTS_ROOT_PATH.parent.resolve())
     proc = run_devnet(
         ["poetry", "run", "starknet-devnet"],
         devnet_port,
     )
+    os.chdir(cwd)
     yield f"http://localhost:{devnet_port}"
     proc.kill()
 


### PR DESCRIPTION
Try to fix CI freezes.