### PR TITLE
Lint everything

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -94,7 +94,8 @@ disable=fixme,
         too-many-arguments,
         too-many-locals,
         invalid-name,
-        no-member
+        no-member,
+        unspecified-encoding
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/binary_entrypoint.py
+++ b/binary_entrypoint.py
@@ -52,7 +52,6 @@ class ProtostarInitializingIndicator:
             return
 
         self._thread.start()
-        return self
 
     def _animate(self):
         for step in cycle(self.steps):

--- a/docs_generator/reference_docs_generator.py
+++ b/docs_generator/reference_docs_generator.py
@@ -34,7 +34,6 @@ class ReferenceDocsGenerator:
 
         return "\n".join(result)
 
-    # pylint: disable=no-self-use
     def _generate_args_markdown(self, arguments: List[Argument]) -> List[str]:
         result: List[str] = []
 

--- a/protostar/starknet/compiler/cairo_compilation.py
+++ b/protostar/starknet/compiler/cairo_compilation.py
@@ -1,8 +1,7 @@
 from pathlib import Path
-from typing import List, cast
+from typing import List
 
 from starkware.cairo.lang.compiler.assembler import assemble
-from starkware.cairo.lang.compiler.identifier_definition import TIdentifierDefinition
 from starkware.cairo.lang.compiler.preprocessor.preprocessor import PreprocessedProgram
 from starkware.cairo.lang.compiler.preprocessor.preprocess_codes import preprocess_codes
 from starkware.cairo.lang.compiler.program import Program

--- a/protostar/starknet/compiler/pass_managers.py
+++ b/protostar/starknet/compiler/pass_managers.py
@@ -1,56 +1,35 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
-from starkware.starknet.public.abi_structs import (
-    prepare_type_for_abi,
-)
+
+from starkware.starknet.public.abi_structs import prepare_type_for_abi
 from starkware.cairo.lang.compiler.ast.code_elements import (
     CodeElementFunction,
+    CodeElement,
+    CodeBlock,
 )
 from starkware.starknet.compiler.starknet_preprocessor import StarknetPreprocessor
-
 from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
-from starkware.cairo.lang.compiler.ast.code_elements import CodeElementFunction
 from starkware.cairo.lang.compiler.cairo_compile import get_module_reader
 from starkware.cairo.lang.compiler.preprocessor.pass_manager import (
     PassManager,
     PassManagerContext,
+    VisitorStage,
 )
 from starkware.starknet.compiler.starknet_pass_manager import starknet_pass_manager
-
-
 from starkware.cairo.lang.compiler.preprocessor.default_pass_manager import (
     PreprocessorStage,
     default_pass_manager,
-)
-from starkware.starknet.security.hints_whitelist import get_hints_whitelist
-
-
-from starkware.cairo.lang.cairo_constants import DEFAULT_PRIME
-from starkware.cairo.lang.compiler.cairo_compile import get_module_reader
-from starkware.cairo.lang.compiler.preprocessor.pass_manager import (
-    PassManager,
-    VisitorStage,
-)
-from starkware.cairo.lang.compiler.preprocessor.default_pass_manager import (
     ModuleCollector,
 )
+from starkware.starknet.security.hints_whitelist import get_hints_whitelist
 from starkware.starknet.compiler.external_wrapper import (
     parse_entry_point_decorators,
-)
-from starkware.starknet.public.abi import AbiType
-
-from starkware.starknet.compiler.starknet_pass_manager import starknet_pass_manager
-from starkware.cairo.lang.compiler.ast.code_elements import (
-    CodeElementFunction,
-    CodeElement,
-)
-from starkware.cairo.lang.compiler.ast.visitor import Visitor
-from starkware.starknet.compiler.external_wrapper import (
     get_abi_entry_type,
     CONSTRUCTOR_DECORATOR,
 )
-from starkware.cairo.lang.compiler.ast.code_elements import CodeBlock
+from starkware.starknet.public.abi import AbiType
+from starkware.cairo.lang.compiler.ast.visitor import Visitor
 
 if TYPE_CHECKING:
     from protostar.starknet.compiler.common import CompilerConfig
@@ -151,7 +130,7 @@ class TestSuitePassMangerFactory(ProtostarPassMangerFactory):
         )
         return manager
 
-
+# pylint: disable=abstract-method
 class ProtostarPreprocessor(StarknetPreprocessor):
     """
     This preprocessor includes types used in contracts storage variables in ABI
@@ -203,7 +182,7 @@ class TestCollectorPreprocessor(Visitor):
     This preprocessor generates simpler and more limited ABI in exchange for performance.
     ABI includes only function types with only names.
     """
-
+    # pylint: disable=unused-argument
     def __init__(self, context: PassManagerContext):
         super().__init__()
         self.abi: AbiType = []
@@ -243,6 +222,7 @@ class PrepareTestCaseVisitor(Visitor):
     This preprocessor removes constructors from module.
     """
 
+    # pylint: disable=unused-argument
     def __init__(self, context: PassManagerContext):
         super().__init__()
 

--- a/protostar/starknet/compiler/pass_managers.py
+++ b/protostar/starknet/compiler/pass_managers.py
@@ -130,6 +130,7 @@ class TestSuitePassMangerFactory(ProtostarPassMangerFactory):
         )
         return manager
 
+
 # pylint: disable=abstract-method
 class ProtostarPreprocessor(StarknetPreprocessor):
     """
@@ -182,6 +183,7 @@ class TestCollectorPreprocessor(Visitor):
     This preprocessor generates simpler and more limited ABI in exchange for performance.
     ABI includes only function types with only names.
     """
+
     # pylint: disable=unused-argument
     def __init__(self, context: PassManagerContext):
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ deploy_prerelease = "python ./scripts/deploy_prerelease.py"
 devnet = "starknet-devnet"
 format = "black ."
 format_check = "black --check protostar"
-lint = "pylint protostar/**/*.py tests/**/*.py scripts/**/*.py"
+lint = "pylint **/*.py"
 local_static_check = [
     "format",
     "lint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ deploy_prerelease = "python ./scripts/deploy_prerelease.py"
 devnet = "starknet-devnet"
 format = "black ."
 format_check = "black --check protostar"
-lint = "pylint protostar"
+lint = "pylint protostar/**/*.py tests/**/*.py scripts/**/*.py"
 local_static_check = [
     "format",
     "lint",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def ensure_devnet_alive(
 ) -> bool:
     for i in range(retries):
         try:
-            res = requests.get(f"http://localhost:{port}/is_alive")
+            res = requests.get(f"http://localhost:{port}/is_alive", timeout=30)
             if res.status_code == 200:
                 return True
         except requests.exceptions.ConnectionError:
@@ -80,7 +80,7 @@ def devnet_port_fixture() -> int:
 
 @pytest.fixture(name="devnet_accounts")
 def devnet_accounts_fixture(devnet_gateway_url: str) -> list[DevnetAccount]:
-    response = requests.get(f"{devnet_gateway_url}/predeployed_accounts")
+    response = requests.get(f"{devnet_gateway_url}/predeployed_accounts", timeout=30)
     devnet_account_dicts = json.loads(response.content)
     return [
         DevnetAccount(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -159,6 +159,7 @@ def protostar(
             stderr=DEVNULL if ignore_stderr else STDOUT,
             encoding="utf-8",
             env=env,
+            check=False,
         )
 
         if not ignore_exit_code:

--- a/tests/e2e/test_building.py
+++ b/tests/e2e/test_building.py
@@ -1,7 +1,7 @@
+import json
 from os import listdir
 from pathlib import Path
 from textwrap import dedent
-import json
 
 import pytest
 
@@ -10,7 +10,7 @@ from tests.e2e.conftest import MyPrivateLibsSetupFixture, ProtostarFixture
 
 @pytest.mark.usefixtures("init")
 def test_default_build(protostar: ProtostarFixture):
-    r = protostar(["build"])
+    protostar(["build"])
     dirs = listdir()
     assert "build" in dirs
 
@@ -143,7 +143,7 @@ def test_disable_hint_validation(protostar: ProtostarFixture):
         dedent(
             """
             %lang starknet
-            
+
             @view
             func use_hint() {
                 tempvar x;
@@ -152,7 +152,7 @@ def test_disable_hint_validation(protostar: ProtostarFixture):
                     ids.x = 42
                 %}
                 assert x = 42;
-            
+
                 return ();
             }
             """
@@ -173,17 +173,17 @@ def test_building_account_contract(protostar: ProtostarFixture):
         dedent(
             """
             %lang starknet
-            
+
             @external
             func __validate__() {
                 return ();
             }
-            
+
             @external
             func __validate_declare__(class_hash: felt) {
                 return ();
             }
-            
+
             @external
             func __execute__() {
                 return ();

--- a/tests/e2e/test_formatting.py
+++ b/tests/e2e/test_formatting.py
@@ -1,7 +1,7 @@
-import pytest
 import os
-
 from pathlib import Path
+
+import pytest
 
 from tests.e2e.conftest import ProtostarFixture, CopyFixture
 

--- a/tests/e2e/test_fuzzing.py
+++ b/tests/e2e/test_fuzzing.py
@@ -30,8 +30,8 @@ x = 3618502788666131213697322783095070105623107215331596699973092056135872020480
 """
         in result
     )
-    assert f"[test:1]:\nTESTING STDOUT" in result
-    assert f"[test:100]:\nTESTING STDOUT" in result
+    assert "[test:1]:\nTESTING STDOUT" in result
+    assert "[test:100]:\nTESTING STDOUT" in result
 
     assert "[FAIL] tests/test_fuzz.cairo test_fails_if_big_many_inputs" in result
     assert (
@@ -50,7 +50,7 @@ def test_fuzzing_changing_seed(protostar: ProtostarFixture, copy_fixture: CopyFi
     seeds = []
     copy_fixture("test_fuzz_single.cairo", "./tests")
 
-    for i in range(0, 2):
+    for _ in range(0, 2):
         result = protostar(
             ["--no-color", "test", "tests/test_fuzz_single.cairo"],
             ignore_exit_code=True,

--- a/tests/e2e/test_misc_commands.py
+++ b/tests/e2e/test_misc_commands.py
@@ -44,7 +44,7 @@ def test_init_existing(protostar_bin: Path):
 
 
 def test_init_ask_existing(protostar_bin: Path):
-    open(Path() / "example.cairo", "a", encoding="utf-8").close()
+    Path("example.cairo").touch()
 
     child = pexpect.spawn(f"{protostar_bin} init")
     child.expect("Your current directory.*", timeout=10)
@@ -89,7 +89,7 @@ def test_migrate_configuration_file(protostar: ProtostarFixture):
         protostar_version = "0.5.0"
 
         ["protostar.project"]
-        libs_path = "./lib"         
+        libs_path = "./lib"
 
         ["protostar.contracts"]
         main = [

--- a/tests/integration/cheatcodes/expect_call/expect_call_test.py
+++ b/tests/integration/cheatcodes/expect_call/expect_call_test.py
@@ -1,11 +1,6 @@
 from pathlib import Path
 
-import pytest
-
-from tests.integration.conftest import (
-    RunTestRunnerFixture,
-    assert_cairo_test_cases,
-)
+from tests.integration.conftest import RunTestRunnerFixture, assert_cairo_test_cases
 
 
 async def test_expect_call(run_test_runner: RunTestRunnerFixture):

--- a/tests/integration/commands/call_command_test.py
+++ b/tests/integration/commands/call_command_test.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from protostar.protostar_exception import ProtostarException
-from protostar.starknet_gateway.gateway_facade import InputValidationException
 from tests.conftest import DevnetAccount, SetPrivateKeyEnvVarFixture
 from tests.data.contracts import UINT256_IDENTITY_CONTRACT
 from tests.integration.conftest import CreateProtostarProjectFixture

--- a/tests/integration/commands/call_command_test.py
+++ b/tests/integration/commands/call_command_test.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from protostar.protostar_exception import ProtostarException
+from protostar.starknet_gateway.gateway_facade import InputValidationException
 from tests.conftest import DevnetAccount, SetPrivateKeyEnvVarFixture
 from tests.data.contracts import UINT256_IDENTITY_CONTRACT
 from tests.integration.conftest import CreateProtostarProjectFixture

--- a/tests/integration/compilation/starknet_compilation_test.py
+++ b/tests/integration/compilation/starknet_compilation_test.py
@@ -1,8 +1,6 @@
 # pylint: disable=invalid-name
 from pathlib import Path
 
-from pytest_mock import MockerFixture
-
 import pytest
 
 from protostar.starknet.compiler.pass_managers import ProtostarPassMangerFactory
@@ -20,7 +18,7 @@ def compiler_fixture() -> StarknetCompiler:
     )
 
 
-async def test_protostar_pass(compiler: StarknetCompiler, mocker: MockerFixture):
+async def test_protostar_pass(compiler: StarknetCompiler):
     contract_class = compiler.compile_contract(Path(__file__).parent / "contract.cairo")
 
     first_type = {

--- a/tests/integration/compilation/test_case_compiler_test.py
+++ b/tests/integration/compilation/test_case_compiler_test.py
@@ -1,6 +1,6 @@
 from pathlib import Path
+
 from starkware.starknet.public.abi import AbiType
-from pytest_mock import MockerFixture
 
 from protostar.starknet.compiler.pass_managers import (
     StarknetPassManagerFactory,
@@ -24,7 +24,7 @@ def oracle_abi() -> AbiType:
     return abi
 
 
-async def test_case_compile_pass_removes_constructor_oracle(mocker: MockerFixture):
+async def test_case_compile_pass_removes_constructor_oracle():
     compiler = StarknetCompiler(
         config=CompilerConfig(include_paths=[], disable_hint_validation=False),
         pass_manager_factory=TestSuitePassMangerFactory,
@@ -39,9 +39,7 @@ async def test_case_compile_pass_removes_constructor_oracle(mocker: MockerFixtur
     ] == contract_class.abi
 
 
-async def test_case_compile_pass_removes_namespace_constructor_oracle(
-    mocker: MockerFixture,
-):
+async def test_case_compile_pass_removes_namespace_constructor_oracle():
     compiler = StarknetCompiler(
         config=CompilerConfig(include_paths=[], disable_hint_validation=False),
         pass_manager_factory=TestSuitePassMangerFactory,

--- a/tests/integration/fuzzing_strategies/fuzzing_strategies_test.py
+++ b/tests/integration/fuzzing_strategies/fuzzing_strategies_test.py
@@ -1,12 +1,7 @@
 from pathlib import Path
 
-import pytest
-
 from protostar.testing.test_results import PassedFuzzTestCaseResult
-from tests.integration.conftest import (
-    RunTestRunnerFixture,
-    assert_cairo_test_cases,
-)
+from tests.integration.conftest import RunTestRunnerFixture, assert_cairo_test_cases
 
 
 async def test_integers(

--- a/tests/integration/gateway/gateway_facade_test.py
+++ b/tests/integration/gateway/gateway_facade_test.py
@@ -230,7 +230,7 @@ async def test_compiled_contract_without_constructor_class_hash(
     devnet_account: DevnetAccount,
 ):
     with pytest.raises(InputValidationException) as ex:
-        result = await gateway_facade.deploy_via_udc(
+        await gateway_facade.deploy_via_udc(
             class_hash=compiled_contract_without_constructor_class_hash,
             abi=contract_abi,
             inputs={"UNKNOWN_INPUT": 42},

--- a/tests/integration/gateway/uint256_as_input_test.py
+++ b/tests/integration/gateway/uint256_as_input_test.py
@@ -6,7 +6,6 @@ from tests.conftest import DevnetAccount, SetPrivateKeyEnvVarFixture
 from tests.data.contracts import CONTRACT_WITH_UINT256_CONSTRUCTOR
 from tests.integration.conftest import CreateProtostarProjectFixture
 from tests.integration.protostar_fixture import ProtostarFixture
-
 from protostar.starknet_gateway.gateway_facade import TransactionException
 from protostar.starknet.data_transformer import CairoOrPythonData
 
@@ -78,7 +77,7 @@ async def test_uint256_as_input_fail(
         )
 
         with pytest.raises(TransactionException):
-            response = await protostar.deploy(
+            await protostar.deploy(
                 class_hash=declare_response.class_hash,
                 gateway_url=devnet_gateway_url,
                 account_address=devnet_account.address,

--- a/tests/integration/protostar_fixture.py
+++ b/tests/integration/protostar_fixture.py
@@ -433,6 +433,7 @@ class TestFriendlyGatewayFacadeFactory(GatewayFacadeFactory):
 
 
 @contextmanager
+# pylint: disable=unused-argument
 def fake_activity_indicator(message: str) -> Generator[None, None, None]:
     yield
 

--- a/tests/integration/testing_cache/test_cache.py
+++ b/tests/integration/testing_cache/test_cache.py
@@ -1,9 +1,15 @@
 import pytest
 
 from protostar.self.cache_io import CacheIO
+from protostar.protostar_exception import ProtostarException
 from tests.integration.conftest import CreateProtostarProjectFixture
 from tests.integration.protostar_fixture import ProtostarFixture
-from tests.data.tests import *
+from tests.data.tests import (
+    TEST_BROKEN,
+    TEST_FAILING,
+    TEST_PARTIALLY_PASSING,
+    TEST_PASSING,
+)
 
 
 @pytest.fixture(name="protostar")
@@ -34,7 +40,7 @@ async def test_execute_all_tests(
             ],
             last_failed=True,
         )
-    except Exception as e:
+    except ProtostarException as e:
         assert str(e) == "Not all test cases passed"
 
     expected_tests_results = {

--- a/tests/integration/testing_timing/testing_timing_test.py
+++ b/tests/integration/testing_timing/testing_timing_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 from pathlib import Path
 from typing import Set
 
@@ -18,7 +19,7 @@ def assert_exec_times_in_desc_order(logs: str) -> None:
 
 def get_test_indices(logs: str) -> Set[int]:
     # "{NUMBER}." -> {NUMBER}
-    return set([int(row.split()[0][:-1]) for row in logs.split("\n")])
+    return set({int(row.split()[0][:-1]) for row in logs.split("\n")})
 
 
 @pytest.fixture(name="testing_summary")


### PR DESCRIPTION
Check linting for every Python file in the project. Disabled unspecified-encoding rule. Currently, the linting checks only the files in the Protostar directory.

---

> Missing timeout argument for method ‘requests.get’ can cause your program to hang indefinitely

Maybe this is why CI kept freezing?