### PR TITLE
Bring back black profile to isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ target-version = [
 ]
 
 [tool.isort]
+profile = "black"
 lines_between_sections = 1
 only_sections = true
 


### PR DESCRIPTION
Set `black` profile in the `isort` configuration. It fixes the racing condition between black formatter and sort organizer in VS Code. This setting was accidentally removed in PR that disabled alphabetical imports.