### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const config = {
   title: "Protostar",
   tagline: "StarkNet smart contract development toolchain",
-  url: "https://your-docusaurus-test-site.com",
+  url: "https://docs.swmansion.com",
   baseUrl: "/protostar/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
While sharing from SFWebViewController it shows wrong URL. Funnily enough, not if you share from Safari.

![6E90EDB6-94C5-4FB9-BCBB-FC4FC33153E8](https://user-images.githubusercontent.com/1151041/209132783-26555546-e507-4fd2-b75c-75510e1f9a9a.jpeg)
