### PR TITLE
fix(install): support ash shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,6 +106,10 @@ add_protostar_to_path() {
         profile=$HOME/.zshrc
         pref_shell=zsh
         ;;
+    */ash)
+        profile=$HOME/.profile
+        pref_shell=ash
+        ;;
     */bash)
         profile=$HOME/.bashrc
         pref_shell=bash


### PR DESCRIPTION
Docker Alpine images come with ash as the default shell instead of bash.

The support of the ash shell would allow using docker containers such as ```python:3.9-alpine``` allowing a quick setup for the Cairo env.