### PR TITLE
Allow passing arrays via named args from the CLI

### DIFF
--- a/protostar/argument_parser/abi_obtainer.py
+++ b/protostar/argument_parser/abi_obtainer.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from protostar.cli import NetworkCommandUtil
+from protostar.starknet_gateway import (
+    AbiResolver,
+    DataTransformerPolicy,
+)
+
+
+async def abi_from_args(args: Any):
+    network_command_util = NetworkCommandUtil(args)
+    gateway_client = network_command_util.get_gateway_client()
+    abi_resolver = AbiResolver(client=gateway_client)
+    data_transformer_policy = DataTransformerPolicy(abi_resolver=abi_resolver)
+    return await data_transformer_policy.resolve_abi_or_fail(
+        address=args.contract_address
+    )

--- a/protostar/argument_parser/argument_parser_facade.py
+++ b/protostar/argument_parser/argument_parser_facade.py
@@ -27,20 +27,29 @@ ArgTypeNameT_contra = TypeVar(
 
 
 def parse_collection_arg(arg: list[Union[int, dict[str, Any]]]):
-    arg_type: Optional[type] = None
+    dict_present = False
     result = arg
     for input_item in result:
-        if arg_type is None:
-            arg_type = type(input_item)
-            continue
-        if not isinstance(input_item, arg_type):
-            raise InconsistentInputTypesException()
+        if isinstance(input_item, dict):
+            dict_present = True
+            break
+    if not isinstance(arg[0], dict) and dict_present:
+        raise InconsistentInputTypesException()
 
-    if arg_type == dict:
+    if isinstance(arg[0], dict):
         parsed = {}
+        last_key = None
         for arg_item in result:
-            assert isinstance(arg_item, dict)
-            parsed.update(dict(arg_item))
+            if isinstance(arg_item, dict):
+                keys = list(arg_item.keys())
+                assert len(keys) == 1
+                last_key = keys[0]
+                parsed.update(dict(arg_item))
+            else:
+                if isinstance(parsed[last_key], list):
+                    parsed[last_key].append(arg_item)
+                else:
+                    parsed[last_key] = [parsed[last_key], arg_item]
         result = parsed
     return result
 

--- a/protostar/argument_parser/argument_parser_facade.py
+++ b/protostar/argument_parser/argument_parser_facade.py
@@ -27,6 +27,9 @@ ArgTypeNameT_contra = TypeVar(
 
 
 def parse_collection_arg(arg: list[Union[int, dict[str, Any]]]):
+    if not arg:
+        return arg
+
     dict_present = False
     result = arg
     for input_item in result:

--- a/protostar/cli/network_command_util.py
+++ b/protostar/cli/network_command_util.py
@@ -93,6 +93,6 @@ class NetworkCommandUtil:
             return StarknetChainId(arg)
         except ValueError as ex:
             raise ProtostarException(
-                "Invalid chain id value.\n"
+                f"Invalid chain id value: {arg}.\n"
                 "Supported chain ids:\n" + "\n".join(supported_chain_ids)
             ) from ex

--- a/protostar/composition_root.py
+++ b/protostar/composition_root.py
@@ -59,6 +59,7 @@ from protostar.upgrader import (
 class DIContainer:
     protostar_cli: ProtostarCLI
     argument_parser_facade: ArgumentParserFacade
+    gateway_facade_factory: Optional[GatewayFacadeFactory] = None
 
 
 def build_di_container(
@@ -242,4 +243,4 @@ def build_di_container(
         parser_resolver=map_protostar_type_name_to_parser,
     )
 
-    return DIContainer(protostar_cli, argument_parser_facade)
+    return DIContainer(protostar_cli, argument_parser_facade, gateway_facade_factory)

--- a/protostar/starknet_gateway/data_transformer_policy.py
+++ b/protostar/starknet_gateway/data_transformer_policy.py
@@ -29,14 +29,14 @@ class DataTransformerPolicy:
         if calldata is None:
             return []
         if isinstance(calldata, dict):
-            abi = abi or await self._resolve_abi_or_fail(address=address)
+            abi = abi or await self.resolve_abi_or_fail(address=address)
             transform = from_python_transformer(
                 contract_abi=abi, fn_name=str(selector), mode="inputs"
             )
             return transform(calldata)
         return calldata
 
-    async def _resolve_abi_or_fail(self, address: Address):
+    async def resolve_abi_or_fail(self, address: Address):
         abi = await self._abi_resolver.resolve(address)
         if abi is None:
             raise ProtostarException(

--- a/protostar/start.py
+++ b/protostar/start.py
@@ -12,13 +12,18 @@ from protostar.composition_root import build_di_container
 from protostar.configuration_profile_cli import ConfigurationProfileCLI
 from protostar.protostar_cli import ProtostarCLI
 from protostar.protostar_exception import UNEXPECTED_PROTOSTAR_ERROR_MSG
+from protostar.argument_parser.abi_obtainer import abi_from_args
 
 
 def main(script_root: Path, start_time: float = 0):
     profile_name = get_active_configuration_profile_name()
     container = build_di_container(script_root, profile_name, start_time)
     args = parse_args(container.argument_parser_facade)
-    run_protostar(container.protostar_cli, container.argument_parser_facade, args)
+    run_protostar(
+        container.protostar_cli,
+        container.argument_parser_facade,
+        args,
+    )
 
 
 def get_active_configuration_profile_name() -> Optional[str]:
@@ -37,8 +42,28 @@ def parse_args(parser: ArgumentParserFacade) -> Any:
         sys.exit(1)
 
 
-def run_protostar(protostar_cli: ProtostarCLI, parser: ArgumentParserFacade, args: Any):
+def run_protostar(
+    protostar_cli: ProtostarCLI,
+    parser: ArgumentParserFacade,
+    args: Any,
+):
     try:
+        abi = asyncio.run(abi_from_args(args))
+        if hasattr(args, "inputs") and isinstance(args.inputs, dict):
+            target_abi_item = None
+            for abi_item in abi:
+                if abi_item["name"] == args.function:
+                    target_abi_item = abi_item
+                    break
+            assert target_abi_item
+            inputs_as_list = []
+            for input_item in target_abi_item["inputs"]:
+                new_item = args.inputs[input_item["name"]]
+                if isinstance(new_item, list):
+                    inputs_as_list += new_item
+                else:
+                    inputs_as_list.append(new_item)
+            args.inputs = inputs_as_list
         asyncio.run(protostar_cli.run(args))
     except CLIApp.CommandNotFoundError:
         parser.print_help()

--- a/protostar/start.py
+++ b/protostar/start.py
@@ -19,11 +19,7 @@ def main(script_root: Path, start_time: float = 0):
     profile_name = get_active_configuration_profile_name()
     container = build_di_container(script_root, profile_name, start_time)
     args = parse_args(container.argument_parser_facade)
-    run_protostar(
-        container.protostar_cli,
-        container.argument_parser_facade,
-        args,
-    )
+    run_protostar(container.protostar_cli, container.argument_parser_facade, args)
 
 
 def get_active_configuration_profile_name() -> Optional[str]:
@@ -48,8 +44,8 @@ def run_protostar(
     args: Any,
 ):
     try:
-        abi = asyncio.run(abi_from_args(args))
         if hasattr(args, "inputs") and isinstance(args.inputs, dict):
+            abi = asyncio.run(abi_from_args(args))
             target_abi_item = None
             for abi_item in abi:
                 if abi_item["name"] == args.function:

--- a/tests/e2e/test_gateway_commands.py
+++ b/tests/e2e/test_gateway_commands.py
@@ -120,6 +120,30 @@ def test_deploying_and_interacting_with_contract(
         "transformed_output": {"res": 166},
     }
 
+    cmd = [
+        "call",
+        "--gateway-url",
+        devnet_gateway_url,
+        "--chain-id",
+        str(StarknetChainId.TESTNET.value),
+        "--contract-address",
+        contract_address,
+        "--function",
+        "sum_array",
+        "--inputs",
+        "arr_len=3",
+        "arr=4",
+        "5",
+        "1",
+        "--json",
+    ]
+    result = protostar(cmd, ignore_stderr=True)
+
+    assert json.loads(result) == {
+        "raw_output": [10],
+        "transformed_output": {"result": 10},
+    }
+
 
 @pytest.mark.usefixtures("init")
 @pytest.mark.parametrize("protostar_version", ["0.0.0"])

--- a/tests/e2e/test_gateway_commands/contract_with_constructor.cairo
+++ b/tests/e2e/test_gateway_commands/contract_with_constructor.cairo
@@ -32,3 +32,15 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     balance.write(initial_balance);
     return ();
 }
+
+@external
+func sum_array{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    arr_len: felt, arr: felt*
+) -> (result: felt) {
+    if (arr_len == 0) {
+        return (result=0);
+    }
+
+    let (sum_of_rest) = sum_array(arr_len=arr_len - 1, arr=arr + 1);
+    return (result=arr[0] + sum_of_rest);
+}


### PR DESCRIPTION
In response to #1327.

This is an early POC.

The idea is to always convert the inputs to a list. If they're passed in the named manner (like `a=1 b=2 c=3`), then, relying on the order of the inputs from the abi, they're converted to the list `1 2 3` (so if you pass `a=1 c=3 b=2` you'll still get `1 2 3`, because in the abi you'll have a correct order of args).

I realize this code's not perfect and there's some refactoring ahead but I'm putting this up to just present the idea for this.

So, to pass an array via named args, you'd do something like this:
```
protostar call --contract-address 0x123 --function sum_array --inputs arr_len=3 arr=4 5 4
```