### PR TITLE
Fix `warp` (and possibly `roll`) Cairo Cheatcode for calls

### DIFF
--- a/protostar/starknet/__init__.py
+++ b/protostar/starknet/__init__.py
@@ -22,3 +22,5 @@ from .data_transformer import (
     CairoOrPythonData,
     PythonData,
 )
+from .local_data_transformation_policy import LocalDataTransformationPolicy
+from .forkable_starknet import ForkableStarknet

--- a/protostar/starknet/__init__.py
+++ b/protostar/starknet/__init__.py
@@ -21,6 +21,7 @@ from .data_transformer import (
     CairoData,
     CairoOrPythonData,
     PythonData,
+    DataTransformerException,
 )
 from .local_data_transformation_policy import LocalDataTransformationPolicy
 from .forkable_starknet import ForkableStarknet

--- a/protostar/starknet/cheatable_execute_entry_point.py
+++ b/protostar/starknet/cheatable_execute_entry_point.py
@@ -154,28 +154,25 @@ class CheatableExecuteEntryPoint(ExecuteEntryPoint):
         hint_locals: dict[str, Any] = {}
 
         cheatcode_factory = CheatableExecuteEntryPoint.cheatcode_factory
-        assert (
-            cheatcode_factory is not None
-        ), "Tried to use CheatableExecuteEntryPoint without cheatcodes."
-
-        cheatcodes = cheatcode_factory.build_cheatcodes(
-            syscall_dependencies=Cheatcode.SyscallDependencies(
-                execute_entry_point_cls=CheatableExecuteEntryPoint,
-                tx_execution_context=tx_execution_context,
-                state=state,
-                resources_manager=resources_manager,
-                caller_address=self.caller_address,
-                contract_address=self.contract_address,
-                general_config=general_config,
-                initial_syscall_ptr=initial_syscall_ptr,
-                shared_internal_calls=syscall_handler.internal_calls,
+        if cheatcode_factory:
+            cheatcodes = cheatcode_factory.build_cheatcodes(
+                syscall_dependencies=Cheatcode.SyscallDependencies(
+                    execute_entry_point_cls=CheatableExecuteEntryPoint,
+                    tx_execution_context=tx_execution_context,
+                    state=state,
+                    resources_manager=resources_manager,
+                    caller_address=self.caller_address,
+                    contract_address=self.contract_address,
+                    general_config=general_config,
+                    initial_syscall_ptr=initial_syscall_ptr,
+                    shared_internal_calls=syscall_handler.internal_calls,
+                )
             )
-        )
-        for cheatcode in cheatcodes:
-            hint_locals[cheatcode.name] = cheatcode.build()
+            for cheatcode in cheatcodes:
+                hint_locals[cheatcode.name] = cheatcode.build()
 
-        for custom_hint_local in cheatcode_factory.build_hint_locals():
-            hint_locals[custom_hint_local.name] = custom_hint_local.build()
+            for custom_hint_local in cheatcode_factory.build_hint_locals():
+                hint_locals[custom_hint_local.name] = custom_hint_local.build()
 
         # endregion
 

--- a/protostar/starknet/local_data_transformation_policy.py
+++ b/protostar/starknet/local_data_transformation_policy.py
@@ -1,0 +1,46 @@
+import collections
+from typing import Optional
+
+from starkware.python.utils import to_bytes, from_bytes
+
+from .address import Address
+from .data_transformer import CairoOrPythonData, CairoData, from_python_transformer
+from .cheatable_state import CheatableCachedState
+
+
+class LocalDataTransformerPolicy:
+    def __init__(self, cheatable_cached_state: CheatableCachedState) -> None:
+        self._cheatable_cached_state = cheatable_cached_state
+
+    async def transform_calldata_to_cairo_data_by_addr(
+        self,
+        contract_address: Address,
+        function_name: str,
+        calldata: Optional[CairoOrPythonData] = None,
+    ) -> CairoData:
+        contract_address_int = int(contract_address)
+        class_hash = await self._cheatable_cached_state.get_class_hash_at(
+            contract_address_int
+        )
+        return await self._transform_calldata_to_cairo_data(
+            class_hash=from_bytes(class_hash, "big"),
+            function_name=function_name,
+            calldata=calldata,
+        )
+
+    async def _transform_calldata_to_cairo_data(
+        self,
+        class_hash: int,
+        function_name: str,
+        calldata: Optional[CairoOrPythonData] = None,
+    ) -> CairoData:
+        if not isinstance(calldata, collections.Mapping):
+            return calldata or []
+        contract_class = await self._cheatable_cached_state.get_contract_class(
+            class_hash=to_bytes(class_hash, 32, "big")
+        )
+        assert contract_class.abi, f"No abi found for the contract at {class_hash}"
+        transformer = from_python_transformer(
+            contract_class.abi, function_name, "inputs"
+        )
+        return transformer(calldata)

--- a/protostar/starknet/local_data_transformation_policy.py
+++ b/protostar/starknet/local_data_transformation_policy.py
@@ -8,7 +8,7 @@ from .data_transformer import CairoOrPythonData, CairoData, from_python_transfor
 from .cheatable_state import CheatableCachedState
 
 
-class LocalDataTransformerPolicy:
+class LocalDataTransformationPolicy:
     def __init__(self, cheatable_cached_state: CheatableCachedState) -> None:
         self._cheatable_cached_state = cheatable_cached_state
 

--- a/protostar/testing/environments/cairo_test_cheatcode_factory.py
+++ b/protostar/testing/environments/cairo_test_cheatcode_factory.py
@@ -17,6 +17,8 @@ from protostar.testing.cairo_cheatcodes.roll_cairo_cheatcode import RollCairoChe
 from protostar.testing.cairo_cheatcodes.warp_cairo_cheatcode import WarpCairoCheatcode
 from protostar.testing.cairo_cheatcodes.call_cairo_cheatcode import CallCairoCheatcode
 from protostar.testing.starkware.test_execution_state import TestExecutionState
+from protostar.testing.use_cases import CallTestingUseCase
+from protostar.starknet import LocalDataTransformationPolicy
 
 
 class CairoTestCheatcodeFactory:
@@ -37,7 +39,13 @@ class CairoTestCheatcodeFactory:
         deploy_cheatcode = DeployCairoCheatcode(
             starknet=self.state.starknet,
         )
-
+        local_data_transformation_policy = LocalDataTransformationPolicy(
+            cheatable_cached_state=self.state.starknet.cheatable_state.cheatable_state
+        )
+        call_use_case = CallTestingUseCase(
+            starknet=self.state.starknet,
+            local_data_transformation_policy=local_data_transformation_policy,
+        )
         return [
             WarpCairoCheatcode(starknet=self.state.starknet),
             RollCairoCheatcode(starknet=self.state.starknet),
@@ -50,5 +58,5 @@ class CairoTestCheatcodeFactory:
                 prepare_cheatcode=prepare_cheatcode,
                 deploy_cheatcode=deploy_cheatcode,
             ),
-            CallCairoCheatcode(starknet=self.state.starknet),
+            CallCairoCheatcode(starknet=self.state.starknet, use_case=call_use_case),
         ]

--- a/protostar/testing/use_cases/__init__.py
+++ b/protostar/testing/use_cases/__init__.py
@@ -1,0 +1,1 @@
+from .call_testing_use_case import CallTestingUseCase

--- a/protostar/testing/use_cases/call_testing_use_case.py
+++ b/protostar/testing/use_cases/call_testing_use_case.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+from protostar.starknet import (
+    Address,
+    CairoOrPythonData,
+    LocalDataTransformationPolicy,
+    CairoData,
+    ForkableStarknet,
+)
+
+
+class CallTestingUseCase:
+    def __init__(
+        self,
+        local_data_transformation_policy: LocalDataTransformationPolicy,
+        starknet: ForkableStarknet,
+    ):
+        self._local_data_transformation_policy = local_data_transformation_policy
+        self._starknet = starknet
+
+    async def execute(
+        self,
+        contract_address: Address,
+        function_name: str,
+        calldata: Optional[CairoOrPythonData] = None,
+    ) -> CairoData:
+        calldata_as_cairo_data = await self._local_data_transformation_policy.transform_calldata_to_cairo_data_by_addr(
+            contract_address,
+            function_name,
+            calldata,
+        )
+        return await self._starknet.call(
+            contract_address,
+            function_name,
+            calldata_as_cairo_data,
+        )

--- a/tests/integration/pure_cairo_vm/cheatcodes/warp/timestamp_contract.cairo
+++ b/tests/integration/pure_cairo_vm/cheatcodes/warp/timestamp_contract.cairo
@@ -1,0 +1,12 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_block_timestamp
+
+@view
+func get_timestamp{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    res: felt
+) {
+    let (timestamp) = get_block_timestamp();
+    return (timestamp,);
+}

--- a/tests/integration/pure_cairo_vm/cheatcodes/warp/warp_cairo_cheatcode_test.py
+++ b/tests/integration/pure_cairo_vm/cheatcodes/warp/warp_cairo_cheatcode_test.py
@@ -1,41 +1,22 @@
 from pathlib import Path
 
-import pytest
-
-from tests.integration.conftest import (
-    CreateProtostarProjectFixture,
-    assert_cairo_test_cases,
-)
-from tests.integration.protostar_fixture import ProtostarFixture
+from tests.integration.conftest import assert_cairo_test_cases
 from tests.integration.pure_cairo_vm.conftest import RunCairoTestRunnerFixture
 
 CONTRACTS_PATH = Path(__file__).parent.parent / "contracts"
 TEST_PATH = Path(__file__).parent
 
 
-@pytest.fixture(autouse=True, name="protostar")
-def protostar_fixture(create_protostar_project: CreateProtostarProjectFixture):
-    with create_protostar_project() as protostar:
-        yield protostar
-
-
-async def test_warp_cheatcode(
-    protostar: ProtostarFixture, run_cairo_test_runner: RunCairoTestRunnerFixture
-):
-    protostar.create_files(
-        {
-            "src/main.cairo": CONTRACTS_PATH / "basic_contract.cairo",
-        }
-    )
+async def test_warp_cheatcode(run_cairo_test_runner: RunCairoTestRunnerFixture):
 
     testing_summary = await run_cairo_test_runner(
-        TEST_PATH
+        Path(__file__).parent
         / "warp_test.cairo",  # TODO #1330: Add assertions after a "call" cheatcode is available
     )
 
     assert_cairo_test_cases(
         testing_summary,
         expected_passed_test_cases_names=[
-            "test_warp",
+            "test_warp_works",
         ],
     )

--- a/tests/integration/pure_cairo_vm/cheatcodes/warp/warp_cairo_cheatcode_test.py
+++ b/tests/integration/pure_cairo_vm/cheatcodes/warp/warp_cairo_cheatcode_test.py
@@ -10,8 +10,7 @@ TEST_PATH = Path(__file__).parent
 async def test_warp_cheatcode(run_cairo_test_runner: RunCairoTestRunnerFixture):
 
     testing_summary = await run_cairo_test_runner(
-        Path(__file__).parent
-        / "warp_test.cairo",  # TODO #1330: Add assertions after a "call" cheatcode is available
+        Path(__file__).parent / "warp_test.cairo",
     )
 
     assert_cairo_test_cases(

--- a/tests/integration/pure_cairo_vm/cheatcodes/warp/warp_test.cairo
+++ b/tests/integration/pure_cairo_vm/cheatcodes/warp/warp_test.cairo
@@ -1,14 +1,13 @@
 from starkware.cairo.common.math import assert_not_zero
 
-func test_warp(){
-    alloc_locals;
-    local deployed_contract_address;
-
+func test_warp_works() {
     %{
-        ids.deployed_contract_address = deploy_contract("main").contract_address
-        warp(123, ids.deployed_contract_address)
-    %}
+        contract_address = deploy_contract("tests/integration/pure_cairo_vm/cheatcodes/warp/timestamp_contract.cairo").contract_address
 
-    assert_not_zero(deployed_contract_address);
+        warp(123, contract_address)
+        result = call(contract_address, "get_timestamp")
+
+        assert result == [123], f"{result}"
+    %}
     return ();
 }


### PR DESCRIPTION
Use `CheatableExecuteEntryPoint` instead of `ExecuteEntryPoint`. I couldn't simply replace the `ExecuteEntryPoint` due to cyclic dependency `CheatableCachedState` -> `Cheaters` -> `CheatableExecuteEntryPoint`. I broke the cycle by moving the `call` code out of the `ContractsCheater` to `CallTestingUseCase`. The cheater keeps the state. `LocalDataTransformationPolicy`.

Related #1330 