### PR TITLE
Fix GLIBC issue

### DIFF
--- a/.github/workflows/assign_issues_to_project.yml
+++ b/.github/workflows/assign_issues_to_project.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   assign_one_project:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Assign to Project
     steps:
     - name: Assign new issues to the project board

--- a/.github/workflows/assign_pr_author.yml
+++ b/.github/workflows/assign_pr_author.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   assign-author:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'software-mansion/protostar' }} # do not run on forks
     steps:
       - uses: toshimaru/auto-author-assign@v1.6.0

--- a/.github/workflows/assign_size_label.yml
+++ b/.github/workflows/assign_size_label.yml
@@ -2,7 +2,7 @@ name: size-label
 on: pull_request
 jobs:
   size-label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'software-mansion/protostar' && github.actor != 'dependabot[bot]' }}
     steps:
       - name: size-label

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-20.04, macos-latest ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9.14
@@ -40,7 +40,7 @@ jobs:
           name: protostar-${{ runner.os }}
           path: protostar.tar.gz
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-deploy:
     name: Test build docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./website

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   setup:
     name: Download deps, install poetry, populate caches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -34,7 +34,7 @@ jobs:
 
   lint:
     name: Check formatting, linting and types
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
 
   unit-and-integration-tests:
     name: Unit and integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
 
   e2e-tests:
     name: End-to-end tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./website

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # TODO: Fix windows gmp.h not found issue, and add a windows binary
+        os: [ubuntu-20.04, macos-latest] # TODO: Fix windows gmp.h not found issue, and add a windows binary
     steps:
       - uses: actions/checkout@v2
       - name: Install protostar

--- a/.pylintrc
+++ b/.pylintrc
@@ -95,7 +95,8 @@ disable=fixme,
         too-many-locals,
         invalid-name,
         no-member,
-        unspecified-encoding
+        unspecified-encoding,
+        no-name-in-module # disabled because of false positives on Ubuntu 20.04
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/e2e/test_upgrading.py
+++ b/tests/e2e/test_upgrading.py
@@ -5,6 +5,9 @@ from tests.e2e.conftest import ProtostarFixture
 
 @pytest.mark.parametrize("protostar_version", ["0.0.0"])
 @pytest.mark.usefixtures("init")
+@pytest.mark.skip(
+    "Protostar 0.9.1 installation fails on Ubuntu 20.04. Remove the skip, after a new release build on Ubuntu 20.04."
+)
 def test_upgrading(protostar: ProtostarFixture):
     assert "0.0.0" in protostar(["--version"])
     assert "ERROR" not in protostar(["upgrade"])


### PR DESCRIPTION
Use Ubuntu 20.04 to build binaries. [Protostar v0.8.1](https://github.com/BibliothecaDAO/realms-contracts/issues/270) doesn't have this problem. [Recently, `ubuntu-latest` was updated to use Ubuntu 22.04.](https://github.com/actions/runner-images/issues/6399)


> You're better off finding a Python built with a lower glibc requirement which in practice means building on an old version of Linux or an old docker image.

https://github.com/pyinstaller/pyinstaller/discussions/5669

Probably Fixes #1293 