### PR TITLE
Break cyclic imports (`protostar.testing` importing from `protostar.commands`)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -95,8 +95,7 @@ disable=fixme,
         too-many-locals,
         invalid-name,
         no-member,
-        unspecified-encoding,
-        no-name-in-module
+        unspecified-encoding
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -95,7 +95,8 @@ disable=fixme,
         too-many-locals,
         invalid-name,
         no-member,
-        unspecified-encoding
+        unspecified-encoding,
+        no-name-in-module
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/protostar/commands/test/test_command.py
+++ b/protostar/commands/test/test_command.py
@@ -14,9 +14,7 @@ from protostar.starknet.compiler.pass_managers import (
     StarknetPassManagerFactory,
     TestCollectorPassManagerFactory,
 )
-from protostar.starknet.compiler.starknet_compilation import (
-    StarknetCompiler,
-)
+from protostar.starknet.compiler.starknet_compilation import StarknetCompiler
 from protostar.starknet.compiler.cairo_compilation import CairoCompiler
 from protostar.starknet.compiler.common import CompilerConfig
 from protostar.testing import (
@@ -261,6 +259,7 @@ A glob or globs to a directory or a test suite, for example:
                 exit_first=exit_first,
                 slowest_tests_to_report_count=slowest_tests_to_report_count,
                 project_root_path=self._project_root_path,
+                write=messenger,
             )
             worker = (
                 CairoTestRunner.worker if use_cairo_test_runner else TestRunner.worker

--- a/protostar/commands/test/test_command.py
+++ b/protostar/commands/test/test_command.py
@@ -4,6 +4,9 @@ from typing import List, Optional
 
 from protostar.cli import ProtostarArgument, ProtostarCommand, MessengerFactory
 from protostar.cli.activity_indicator import ActivityIndicator
+from protostar.commands.test.messages.testing_summary_message import (
+    TestingSummaryResultMessage,
+)
 from protostar.commands.test.testing_live_logger import TestingLiveLogger
 from protostar.compiler import ProjectCairoPathBuilder
 from protostar.io.log_color_provider import LogColorProvider
@@ -277,9 +280,13 @@ A glob or globs to a directory or a test suite, for example:
                 active_profile_name=self._active_profile_name,
                 cwd=self._cwd,
                 gas_estimation_enabled=gas_estimation_enabled,
-                messenger=messenger,
-                testing_summary=testing_summary,
-                slowest_tests_to_report_count=slowest_tests_to_report_count,
+                on_exit_first=lambda: messenger(
+                    TestingSummaryResultMessage(
+                        test_collector_result=test_collector_result,
+                        testing_summary=testing_summary,
+                        slowest_tests_to_report_count=slowest_tests_to_report_count,
+                    )
+                ),
             )
 
         return testing_summary

--- a/protostar/testing/test_scheduler.py
+++ b/protostar/testing/test_scheduler.py
@@ -1,21 +1,17 @@
 import multiprocessing
 import signal
+import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional
-import dataclasses
 
-from protostar.io.output import Messenger, HumanMessenger
+from protostar.io.output import Messenger
 from protostar.commands.test.messages import TestingSummaryResultMessage
-from protostar.testing import (
-    TestResult,
-    TestingSummary,
-)
+from protostar.testing import TestResult, TestingSummary
 
 from .test_collector import TestCollector
 from .test_runner import TestRunner
 from .test_shared_tests_state import SharedTestsState
 from .testing_seed import Seed
-
 
 if TYPE_CHECKING:
     from protostar.commands.test.testing_live_logger import TestingLiveLogger
@@ -100,20 +96,10 @@ class TestScheduler:
                     initializer=_init_worker,
                 ) as pool:
                     results = pool.map_async(self._worker, setups)
-
-                    if isinstance(messenger, HumanMessenger):
-                        self._live_logger.log_human(
-                            shared_tests_state,
-                            test_collector_result,
-                            messenger,
-                        )
-                    else:
-                        self._live_logger.log_json(
-                            shared_tests_state,
-                            test_collector_result,
-                            messenger,
-                        )
-
+                    self._live_logger.log(
+                        shared_tests_state,
+                        test_collector_result,
+                    )
                     if exit_first and shared_tests_state.any_failed_or_broken():
                         pool.terminate()
                         return

--- a/protostar/testing/test_scheduler.py
+++ b/protostar/testing/test_scheduler.py
@@ -4,10 +4,7 @@ import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional
 
-from protostar.io.output import Messenger
-from protostar.commands.test.messages import TestingSummaryResultMessage
-from protostar.testing import TestResult, TestingSummary
-
+from .test_results import TestResult
 from .test_collector import TestCollector
 from .test_runner import TestRunner
 from .test_shared_tests_state import SharedTestsState
@@ -54,9 +51,7 @@ class TestScheduler:
         cwd: Path,
         active_profile_name: Optional[str],
         gas_estimation_enabled: bool,
-        messenger: Messenger,
-        slowest_tests_to_report_count: int,
-        testing_summary: TestingSummary,
+        on_exit_first: Callable[[], None],
     ):
         with multiprocessing.Manager() as manager:
             shared_tests_state = SharedTestsState(
@@ -81,13 +76,7 @@ class TestScheduler:
 
             # A test case was broken
             if exit_first and shared_tests_state.any_failed_or_broken():
-                messenger(
-                    TestingSummaryResultMessage(
-                        test_collector_result=test_collector_result,
-                        testing_summary=testing_summary,
-                        slowest_tests_to_report_count=slowest_tests_to_report_count,
-                    )
-                )
+                on_exit_first()
                 return
 
             try:


### PR DESCRIPTION
Break cyclic imports caused by `protostar.testing` component importing from `protostar.commands`. 

For some reason, Pylint started complaining when I changed the os from the `ubuntu-latest` to `ubuntu-20.04` in this PR https://github.com/software-mansion/protostar/actions/runs/3911262001/jobs/6685094177.