### PR TITLE
Improve `assert_cairo_test_cases`' feedback

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, ContextManager, List, Optional, Set, cast
+from typing import Any, Callable, ContextManager, List, Optional, Set, cast
 
 import pytest
 from pytest import TempPathFactory
@@ -12,11 +12,12 @@ from starkware.starknet.public.abi import AbiType
 from typing_extensions import Protocol
 
 from protostar.commands.test.test_command import TestCommand
+from protostar.commands.test.test_result_formatter import format_test_result
 from protostar.compiler.project_cairo_path_builder import ProjectCairoPathBuilder
 from protostar.io.log_color_provider import LogColorProvider
 from protostar.testing import TestingSummary
 from protostar.cli import MessengerFactory
-
+from protostar.testing.test_results import TestCaseResult
 from tests.conftest import TESTS_ROOT_PATH, run_devnet
 from tests.integration._conftest import ProtostarFixture, create_protostar_fixture
 
@@ -81,7 +82,42 @@ def assert_cairo_test_cases(
         skipped=set(expected_skipped_test_cases_names),
     )
 
+    name_to_test_case_result = {
+        test_result.test_case_name: test_result
+        for test_result in testing_summary.test_results
+        if isinstance(test_result, TestCaseResult)
+    }
+    diff = show_diff_between_cairo_test_cases(
+        name_to_test_case_result, expected, actual
+    )
+    assert diff == ""
     assert actual == expected
+
+
+def show_diff_between_cairo_test_cases(
+    name_to_test_case_result: dict[str, Any],
+    expected: CairoTestCases,
+    actual: CairoTestCases,
+) -> str:
+    lines: list[str] = []
+    result_types = ["passed", "failed", "broken", "skipped"]
+    for expected_result_type in result_types:
+        for expected_test_case_name in getattr(expected, expected_result_type):
+            if expected_test_case_name in getattr(actual, expected_result_type):
+                continue
+            lines.append(
+                (
+                    f"Expected '{expected_test_case_name}' to be {expected_result_type}, got:"
+                )
+            )
+            lines.append(
+                format_test_result(
+                    name_to_test_case_result[expected_test_case_name]
+                ).format_human(LogColorProvider())
+            )
+            lines.append("")
+            break
+    return "\n".join(lines)
 
 
 @pytest.fixture(name="devnet_gateway_url", scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -90,7 +90,8 @@ def assert_cairo_test_cases(
     diff = show_diff_between_cairo_test_cases(
         name_to_test_case_result, expected, actual
     )
-    assert diff == ""
+    if diff:
+        assert False, diff
     assert actual == expected
 
 
@@ -110,6 +111,9 @@ def show_diff_between_cairo_test_cases(
                     f"Expected '{expected_test_case_name}' to be {expected_result_type}, got:"
                 )
             )
+            if expected_test_case_name not in name_to_test_case_result:
+                lines.append("nothing — no such test case result found")
+                break
             lines.append(
                 format_test_result(
                     name_to_test_case_result[expected_test_case_name]

--- a/tests/integration/conftest_test.py
+++ b/tests/integration/conftest_test.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from protostar.commands.test.test_result_formatter import format_test_result
+from protostar.io import log_color_provider
+from protostar.starknet.cheatable_starknet_exceptions import ReportedException
+from protostar.testing.test_results import FailedTestCaseResult
+from tests.integration.conftest import (
+    CairoTestCases,
+    show_diff_between_cairo_test_cases,
+)
+
+
+def test_diff_between_test_cases():
+    name_to_actual_test_case = {
+        "foo": FailedTestCaseResult(
+            test_case_name="foo",
+            file_path=Path("./path"),
+            exception=ReportedException(),
+            captured_stdout={},
+            execution_time=0,
+        )
+    }
+
+    expected_cairo_test_cases = CairoTestCases(
+        passed=set(["foo"]),
+        failed=set(["bar"]),
+        broken=set(),
+        skipped=set(),
+    )
+    actual_cairo_test_cases = CairoTestCases(
+        passed=set(),
+        failed=set(["foo", "bar"]),
+        broken=set(),
+        skipped=set(),
+    )
+
+    diff = show_diff_between_cairo_test_cases(
+        name_to_actual_test_case, expected_cairo_test_cases, actual_cairo_test_cases
+    )
+
+    assert "Expected 'foo' to be passed, got" in diff
+    assert (
+        format_test_result(name_to_actual_test_case["foo"]).format_human(
+            log_color_provider
+        )
+        in diff
+    )


### PR DESCRIPTION
Improve 'assert_cairo_test_cases' feedback. `CairoCheatcodes` cairo tests can't be run with Protostar in the console. Checking test results with a debugger is annoying.

Before:
![Screenshot 2023-01-20 at 16 27 23](https://user-images.githubusercontent.com/9629577/213739910-5385005f-426e-4f71-9ac1-a19e094ea12e.png)

After:
![Screenshot 2023-01-20 at 16 33 03](https://user-images.githubusercontent.com/9629577/213749194-ccf47b3e-af7e-4824-b654-8a3aad0724a7.jpg)

