### PR TITLE
CheatableStarknetFacade

### DIFF
--- a/protostar/cairo_testing/cairo_test_execution_state.py
+++ b/protostar/cairo_testing/cairo_test_execution_state.py
@@ -1,25 +1,13 @@
 import dataclasses
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import cast
 
-from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash_func
-from starkware.starknet.business_logic.fact_state.patricia_state import (
-    PatriciaStateReader,
-)
-from starkware.starknet.business_logic.fact_state.state import SharedState
-from starkware.starknet.business_logic.state.state_api_objects import BlockInfo
-from starkware.starknet.definitions.general_config import StarknetGeneralConfig
-from starkware.starknet.testing.starknet import Starknet
-from starkware.starknet.testing.state import StarknetState
-from starkware.storage.dict_storage import DictStorage
-from starkware.storage.storage import FactFetchingContext
 from typing_extensions import Self
 
-from protostar.compiler import ProjectCompiler
-from protostar.cheatable_starknet.cheatables.cheatable_cached_state import (
-    CheatableCachedState,
+from protostar.cheatable_starknet.cheatables.cheatable_starknet_facade import (
+    CheatableStarknetFacade,
 )
+from protostar.compiler import ProjectCompiler
 from protostar.testing.stopwatch import Stopwatch
 from protostar.testing.test_config import TestConfig
 from protostar.testing.test_context import TestContext
@@ -28,16 +16,12 @@ from protostar.testing.test_output_recorder import OutputRecorder
 
 @dataclass
 class CairoTestExecutionState:
-    starknet: Starknet
+    starknet: CheatableStarknetFacade
     stopwatch: Stopwatch
     output_recorder: OutputRecorder
     context: TestContext
     config: TestConfig
     project_compiler: ProjectCompiler
-
-    @property
-    def cheatable_state(self) -> CheatableCachedState:
-        return cast(CheatableCachedState, self.starknet.state.state)
 
     def fork(self) -> Self:
         return dataclasses.replace(
@@ -46,38 +30,15 @@ class CairoTestExecutionState:
             config=deepcopy(self.config),
             output_recorder=self.output_recorder.fork(),
             stopwatch=self.stopwatch.fork(),
-            starknet=self.starknet.copy(),
+            starknet=self.starknet.fork(),
         )
 
     @classmethod
     async def from_test_config(
         cls, test_config: TestConfig, project_compiler: ProjectCompiler
     ):
-        general_config = StarknetGeneralConfig()
-        ffc = FactFetchingContext(storage=DictStorage(), hash_func=pedersen_hash_func)
-        empty_shared_state = await SharedState.empty(
-            ffc=ffc, general_config=general_config
-        )
-
-        state_reader = PatriciaStateReader(
-            global_state_root=empty_shared_state.contract_states,
-            ffc=ffc,
-            contract_class_storage=ffc.storage,
-        )
-
         return cls(
-            starknet=Starknet(
-                state=StarknetState(
-                    general_config=general_config,
-                    state=CheatableCachedState(
-                        block_info=BlockInfo.empty(
-                            sequencer_address=general_config.sequencer_address
-                        ),
-                        state_reader=state_reader,
-                        contract_class_cache={},
-                    ),
-                )
-            ),
+            starknet=await CheatableStarknetFacade.create(),
             stopwatch=Stopwatch(),
             output_recorder=OutputRecorder(),
             context=TestContext(),

--- a/protostar/cairo_testing/cairo_test_execution_state.py
+++ b/protostar/cairo_testing/cairo_test_execution_state.py
@@ -16,12 +16,25 @@ from protostar.testing.test_output_recorder import OutputRecorder
 
 @dataclass
 class CairoTestExecutionState:
-    starknet: CheatableStarknetFacade
+    cheatable_starknet_facade: CheatableStarknetFacade
     stopwatch: Stopwatch
     output_recorder: OutputRecorder
     context: TestContext
     config: TestConfig
     project_compiler: ProjectCompiler
+
+    @classmethod
+    async def from_test_config(
+        cls, test_config: TestConfig, project_compiler: ProjectCompiler
+    ):
+        return cls(
+            cheatable_starknet_facade=await CheatableStarknetFacade.create(),
+            stopwatch=Stopwatch(),
+            output_recorder=OutputRecorder(),
+            context=TestContext(),
+            config=test_config,
+            project_compiler=project_compiler,
+        )
 
     def fork(self) -> Self:
         return dataclasses.replace(
@@ -30,18 +43,5 @@ class CairoTestExecutionState:
             config=deepcopy(self.config),
             output_recorder=self.output_recorder.fork(),
             stopwatch=self.stopwatch.fork(),
-            starknet=self.starknet.fork(),
-        )
-
-    @classmethod
-    async def from_test_config(
-        cls, test_config: TestConfig, project_compiler: ProjectCompiler
-    ):
-        return cls(
-            starknet=await CheatableStarknetFacade.create(),
-            stopwatch=Stopwatch(),
-            output_recorder=OutputRecorder(),
-            context=TestContext(),
-            config=test_config,
-            project_compiler=project_compiler,
+            cheatable_starknet_facade=self.cheatable_starknet_facade.fork(),
         )

--- a/protostar/cairo_testing/cheatcode_factories/cairo_setup_cheatcode_factory.py
+++ b/protostar/cairo_testing/cheatcode_factories/cairo_setup_cheatcode_factory.py
@@ -1,8 +1,8 @@
 # pylint: disable=duplicate-code
 from typing import List
 
-from protostar.cheatable_starknet.cheatables.cheatable_cached_state import (
-    CheatableCachedState,
+from protostar.cheatable_starknet.cheatables.cheatable_starknet_facade import (
+    CheatableStarknetFacade,
 )
 from protostar.cheatable_starknet.cheatcodes.load_cairo_cheatcode import (
     LoadCairoCheatcode,
@@ -45,17 +45,23 @@ from protostar.cheatable_starknet.cheaters.storage import StorageCairoCheater
 class CairoSetupCheatcodeFactory:
     def __init__(
         self,
-        cheatable_state: CheatableCachedState,
+        cheatable_starknet_facade: CheatableStarknetFacade,
         project_compiler: ProjectCompiler,
     ):
-        self.cheatable_state = cheatable_state
+        self._cheatable_starknet = cheatable_starknet_facade
         self.project_compiler = project_compiler
 
     def build_cheatcodes(self) -> List[CairoCheatcode]:
         cheaters = CairoCheaters(
-            block_info=BlockInfoCairoCheater(cheatable_state=self.cheatable_state),
-            contracts=ContractsCairoCheater(cheatable_state=self.cheatable_state),
-            storage=StorageCairoCheater(cheatable_state=self.cheatable_state),
+            block_info=BlockInfoCairoCheater(
+                cheatable_state=self._cheatable_starknet.cheatable_state
+            ),
+            contracts=ContractsCairoCheater(
+                cheatable_starknet_facade=self._cheatable_starknet,
+            ),
+            storage=StorageCairoCheater(
+                cheatable_state=self._cheatable_starknet.cheatable_state
+            ),
         )
         declare_cheatcode = DeclareCairoCheatcode(
             cheaters=cheaters,

--- a/protostar/cairo_testing/cheatcode_factories/cairo_test_cheatcode_factory.py
+++ b/protostar/cairo_testing/cheatcode_factories/cairo_test_cheatcode_factory.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from protostar.cheatable_starknet.cheatables.cheatable_cached_state import (
-    CheatableCachedState,
+from protostar.cheatable_starknet.cheatables.cheatable_starknet_facade import (
+    CheatableStarknetFacade,
 )
 from protostar.cheatable_starknet.cheatcodes.load_cairo_cheatcode import (
     LoadCairoCheatcode,
@@ -47,17 +47,23 @@ from protostar.cheatable_starknet.cheaters.storage import StorageCairoCheater
 class CairoTestCheatcodeFactory:
     def __init__(
         self,
-        cheatable_state: CheatableCachedState,
+        cheatable_starknet_facade: CheatableStarknetFacade,
         project_compiler: ProjectCompiler,
     ):
-        self.cheatable_state = cheatable_state
+        self._cheatable_starknet_facade = cheatable_starknet_facade
         self.project_compiler = project_compiler
 
     def build_cheatcodes(self) -> List[CairoCheatcode]:
         cheaters = CairoCheaters(
-            block_info=BlockInfoCairoCheater(cheatable_state=self.cheatable_state),
-            contracts=ContractsCairoCheater(cheatable_state=self.cheatable_state),
-            storage=StorageCairoCheater(cheatable_state=self.cheatable_state),
+            block_info=BlockInfoCairoCheater(
+                cheatable_state=self._cheatable_starknet_facade.cheatable_state
+            ),
+            contracts=ContractsCairoCheater(
+                cheatable_starknet_facade=self._cheatable_starknet_facade
+            ),
+            storage=StorageCairoCheater(
+                cheatable_state=self._cheatable_starknet_facade.cheatable_state
+            ),
         )
         declare_cheatcode = DeclareCairoCheatcode(
             cheaters=cheaters,

--- a/protostar/cairo_testing/execution_environments/cairo_setup_case_execution_environment.py
+++ b/protostar/cairo_testing/execution_environments/cairo_setup_case_execution_environment.py
@@ -26,7 +26,7 @@ class CairoSetupCaseExecutionEnvironment(CairoExecutionEnvironment):
     def _get_hint_locals(self, state: CairoTestExecutionState) -> HintLocalsDict:
         hint_locals: HintLocalsDict = {}
         cheatcode_factory = CairoSetupCheatcodeFactory(
-            cheatable_state=state.cheatable_state,
+            cheatable_state=state.starknet.cheatable_state,
             project_compiler=state.project_compiler,
         )
         cheatcodes = cheatcode_factory.build_cheatcodes()

--- a/protostar/cairo_testing/execution_environments/cairo_setup_case_execution_environment.py
+++ b/protostar/cairo_testing/execution_environments/cairo_setup_case_execution_environment.py
@@ -26,7 +26,7 @@ class CairoSetupCaseExecutionEnvironment(CairoExecutionEnvironment):
     def _get_hint_locals(self, state: CairoTestExecutionState) -> HintLocalsDict:
         hint_locals: HintLocalsDict = {}
         cheatcode_factory = CairoSetupCheatcodeFactory(
-            cheatable_state=state.starknet.cheatable_state,
+            cheatable_starknet_facade=state.cheatable_starknet_facade,
             project_compiler=state.project_compiler,
         )
         cheatcodes = cheatcode_factory.build_cheatcodes()

--- a/protostar/cairo_testing/execution_environments/cairo_setup_execution_environment.py
+++ b/protostar/cairo_testing/execution_environments/cairo_setup_execution_environment.py
@@ -26,7 +26,7 @@ class CairoSetupExecutionEnvironment(CairoExecutionEnvironment):
     def _get_hint_locals(self, state: CairoTestExecutionState) -> HintLocalsDict:
         hint_locals: HintLocalsDict = {}
         cheatcode_factory = CairoSetupCheatcodeFactory(
-            cheatable_state=state.cheatable_state,
+            cheatable_state=state.starknet.cheatable_state,
             project_compiler=state.project_compiler,
         )
         cheatcodes = cheatcode_factory.build_cheatcodes()

--- a/protostar/cairo_testing/execution_environments/cairo_setup_execution_environment.py
+++ b/protostar/cairo_testing/execution_environments/cairo_setup_execution_environment.py
@@ -26,7 +26,7 @@ class CairoSetupExecutionEnvironment(CairoExecutionEnvironment):
     def _get_hint_locals(self, state: CairoTestExecutionState) -> HintLocalsDict:
         hint_locals: HintLocalsDict = {}
         cheatcode_factory = CairoSetupCheatcodeFactory(
-            cheatable_state=state.starknet.cheatable_state,
+            cheatable_starknet_facade=state.cheatable_starknet_facade,
             project_compiler=state.project_compiler,
         )
         cheatcodes = cheatcode_factory.build_cheatcodes()

--- a/protostar/cairo_testing/execution_environments/cairo_test_execution_environment.py
+++ b/protostar/cairo_testing/execution_environments/cairo_test_execution_environment.py
@@ -46,7 +46,7 @@ class CairoTestExecutionEnvironment(CairoExecutionEnvironment):
     def _get_hint_locals(self, state: CairoTestExecutionState) -> HintLocalsDict:
         hint_locals: HintLocalsDict = {}
         cheatcode_factory = CairoTestCheatcodeFactory(
-            cheatable_state=state.starknet.cheatable_state,
+            cheatable_starknet_facade=state.cheatable_starknet_facade,
             project_compiler=state.project_compiler,
         )
         cheatcodes = cheatcode_factory.build_cheatcodes()

--- a/protostar/cairo_testing/execution_environments/cairo_test_execution_environment.py
+++ b/protostar/cairo_testing/execution_environments/cairo_test_execution_environment.py
@@ -2,10 +2,7 @@ from typing import Any
 
 from starkware.cairo.lang.compiler.program import Program
 
-from protostar.testing.environments.execution_environment import (
-    TestExecutionResult,
-)
-
+from protostar.testing.environments.execution_environment import TestExecutionResult
 from protostar.testing.cheatcodes.expect_revert_cheatcode import ExpectRevertContext
 from protostar.testing.hook import Hook
 from protostar.testing.test_context import TestContextHintLocal
@@ -49,7 +46,7 @@ class CairoTestExecutionEnvironment(CairoExecutionEnvironment):
     def _get_hint_locals(self, state: CairoTestExecutionState) -> HintLocalsDict:
         hint_locals: HintLocalsDict = {}
         cheatcode_factory = CairoTestCheatcodeFactory(
-            cheatable_state=state.cheatable_state,
+            cheatable_state=state.starknet.cheatable_state,
             project_compiler=state.project_compiler,
         )
         cheatcodes = cheatcode_factory.build_cheatcodes()

--- a/protostar/cheatable_starknet/cheatables/cheatable_execute_entry_point.py
+++ b/protostar/cheatable_starknet/cheatables/cheatable_execute_entry_point.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from typing import Optional, Tuple, cast
 from copy import deepcopy
 
+from starkware.starknet.business_logic.execution.objects import (
+    CallType,
+    CallInfo,
+    TransactionExecutionContext,
+)
 from starkware.cairo.common.cairo_function_runner import CairoFunctionRunner
 from starkware.cairo.lang.vm.relocatable import RelocatableValue
 from starkware.cairo.lang.vm.security import SecurityError
@@ -18,10 +23,6 @@ from starkware.python.utils import to_bytes
 from starkware.starknet.business_logic.execution.execute_entry_point import (
     ExecuteEntryPoint,
 )
-from starkware.starknet.business_logic.execution.objects import (
-    CallInfo,
-    TransactionExecutionContext,
-)
 from starkware.starknet.business_logic.fact_state.state import ExecutionResourcesManager
 from starkware.starknet.business_logic.state.state import StateSyncifier
 from starkware.starknet.business_logic.state.state_api import State, SyncState
@@ -34,6 +35,7 @@ from starkware.starkware_utils.error_handling import (
     StarkException,
     wrap_with_stark_exception,
 )
+from starkware.starknet.services.api.contract_class import EntryPointType
 
 from protostar.cheatable_starknet.cheaters.transaction_revert_exception import (
     TransactionRevertException,
@@ -60,11 +62,18 @@ class CheatableExecuteEntryPoint(ExecuteEntryPoint):
         contract_address: Address,
         calldata: list[int],
         entry_point_selector: int,
+        entry_point_type: EntryPointType = EntryPointType.EXTERNAL,
+        call_type: CallType = CallType.CALL,
+        class_hash: Optional[int] = None,
     ):
         return cls.create_for_testing(
             entry_point_selector=entry_point_selector,
             calldata=calldata,
             contract_address=int(contract_address),
+            entry_point_type=entry_point_type,
+            call_type=call_type,
+            caller_address=0,
+            class_hash=to_bytes(class_hash) if class_hash else None,
         )
 
     def _run(

--- a/protostar/cheatable_starknet/cheatables/cheatable_starknet_facade.py
+++ b/protostar/cheatable_starknet/cheatables/cheatable_starknet_facade.py
@@ -61,7 +61,7 @@ class CheatableStarknetFacade:
         return cast(CheatableCachedState, self._starknet.state.state)
 
     def fork(self):
-        return CheatableStarknetFacade(self._starknet)
+        return CheatableStarknetFacade(self._starknet.copy())
 
     async def invoke(
         self, contract_address: Address, function_name: str, calldata: CairoData

--- a/protostar/cheatable_starknet/cheatables/cheatable_starknet_facade.py
+++ b/protostar/cheatable_starknet/cheatables/cheatable_starknet_facade.py
@@ -89,4 +89,4 @@ class CheatableStarknetFacade:
             state=copy.deepcopy(self.cheatable_state),
             general_config=StarknetGeneralConfig(),
         )
-        return result.calldata
+        return result.retdata

--- a/protostar/cheatable_starknet/cheatables/cheatable_starknet_facade.py
+++ b/protostar/cheatable_starknet/cheatables/cheatable_starknet_facade.py
@@ -1,0 +1,58 @@
+from typing import cast
+
+from starkware.starknet.testing.starknet import Starknet
+from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash_func
+from starkware.starknet.business_logic.fact_state.patricia_state import (
+    PatriciaStateReader,
+)
+from starkware.starknet.business_logic.fact_state.state import SharedState
+from starkware.starknet.business_logic.state.state_api_objects import BlockInfo
+from starkware.starknet.definitions.general_config import StarknetGeneralConfig
+from starkware.starknet.testing.state import StarknetState
+from starkware.storage.dict_storage import DictStorage
+from starkware.storage.storage import FactFetchingContext
+
+from protostar.cheatable_starknet.cheatables.cheatable_cached_state import (
+    CheatableCachedState,
+)
+
+
+class CheatableStarknetFacade:
+    @classmethod
+    async def create(cls):
+        general_config = StarknetGeneralConfig()
+        ffc = FactFetchingContext(storage=DictStorage(), hash_func=pedersen_hash_func)
+        empty_shared_state = await SharedState.empty(
+            ffc=ffc, general_config=general_config
+        )
+
+        state_reader = PatriciaStateReader(
+            global_state_root=empty_shared_state.contract_states,
+            ffc=ffc,
+            contract_class_storage=ffc.storage,
+        )
+
+        return cls(
+            starknet=Starknet(
+                state=StarknetState(
+                    general_config=general_config,
+                    state=CheatableCachedState(
+                        block_info=BlockInfo.empty(
+                            sequencer_address=general_config.sequencer_address
+                        ),
+                        state_reader=state_reader,
+                        contract_class_cache={},
+                    ),
+                )
+            ),
+        )
+
+    def __init__(self, starknet: Starknet) -> None:
+        self._starknet = starknet
+
+    @property
+    def cheatable_state(self) -> CheatableCachedState:
+        return cast(CheatableCachedState, self._starknet.state.state)
+
+    def fork(self):
+        return CheatableStarknetFacade(self._starknet)

--- a/protostar/cheatable_starknet/cheaters/contracts.py
+++ b/protostar/cheatable_starknet/cheaters/contracts.py
@@ -4,11 +4,7 @@ from typing import List, Optional, TYPE_CHECKING
 
 from starkware.python.utils import to_bytes, from_bytes
 from starkware.starknet.business_logic.transaction.objects import InternalDeclare
-from starkware.starknet.public.abi import (
-    AbiType,
-    get_selector_from_name,
-    CONSTRUCTOR_ENTRY_POINT_SELECTOR,
-)
+from starkware.starknet.public.abi import AbiType, CONSTRUCTOR_ENTRY_POINT_SELECTOR
 from starkware.starknet.services.api.gateway.transaction import (
     DEFAULT_DECLARE_SENDER_ADDRESS,
 )
@@ -28,9 +24,6 @@ from protostar.contract_types import (
     PreparedContract,
     DeclaredContract,
     DeployedContract,
-)
-from protostar.cheatable_starknet.cheatables.cheatable_execute_entry_point import (
-    CheatableExecuteEntryPoint,
 )
 from protostar.starknet.types import ClassHashType
 from protostar.starknet.address import Address

--- a/protostar/cheatable_starknet/cheaters/contracts.py
+++ b/protostar/cheatable_starknet/cheaters/contracts.py
@@ -273,16 +273,11 @@ class ContractsCairoCheater:
             function_name=function_name,
             calldata=calldata,
         )
-        entry_point = CheatableExecuteEntryPoint.create_for_protostar(
+        await self._cheatable_starknet_facade.invoke(
             contract_address=contract_address,
+            function_name=function_name,
             calldata=cairo_calldata,
-            entry_point_selector=get_selector_from_name(function_name),
         )
-        with self._cheatable_state.copy_and_apply() as state_copy:
-            await entry_point.execute_for_testing(
-                state=state_copy,
-                general_config=StarknetGeneralConfig(),
-            )
 
     def prank(self, caller_address: Address, target_address: Address):
         self._cheatable_state.set_pranked_address(

--- a/protostar/cheatable_starknet/cheaters/contracts.py
+++ b/protostar/cheatable_starknet/cheaters/contracts.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING
 
@@ -257,16 +256,11 @@ class ContractsCairoCheater:
             function_name=function_name,
             calldata=calldata,
         )
-        entry_point = CheatableExecuteEntryPoint.create_for_protostar(
+        return await self._cheatable_starknet_facade.call(
             contract_address=contract_address,
+            function_name=function_name,
             calldata=cairo_calldata,
-            entry_point_selector=get_selector_from_name(function_name),
         )
-        result = await entry_point.execute_for_testing(
-            state=copy.deepcopy(self._cheatable_state),
-            general_config=StarknetGeneralConfig(),
-        )
-        return result.retdata
 
     async def invoke(
         self,


### PR DESCRIPTION
Move Starknet's implementation details in `CheatableStarknetFacade`. Simplify `CairoTestExecutionState` and `ContractsCheater`. Code responsible for deploying and declaring wasn't moved in this PR. I plan to use `CheatableStarknetFacade` in PR with Expect Events.