### PR TITLE
Make git error message more descriptive

### DIFF
--- a/protostar/commands/install/install_package_from_repo.py
+++ b/protostar/commands/install/install_package_from_repo.py
@@ -35,5 +35,5 @@ def install_package_from_repo(
 
     repo.add_submodule(url, package_dir, name, tag)
     repo.add(package_dir)
-    if repo.get_status().files_to_be_committed:
+    if repo.get_status().staged_file_paths:
         repo.commit(f"add {name}")

--- a/protostar/commands/install/install_package_from_repo.py
+++ b/protostar/commands/install/install_package_from_repo.py
@@ -35,4 +35,5 @@ def install_package_from_repo(
 
     repo.add_submodule(url, package_dir, name, tag)
     repo.add(package_dir)
-    repo.commit(f"add {name}")
+    if repo.get_status().files_to_be_committed:
+        repo.commit(f"add {name}")

--- a/protostar/commands/install/install_package_from_repo_test.py
+++ b/protostar/commands/install/install_package_from_repo_test.py
@@ -15,9 +15,31 @@ def repo_url():
 
 
 def test_successful_installation(tmpdir: str, repo_url: str):
-    install_package_from_repo("foo", repo_url, Path(tmpdir), Path(tmpdir) / "lib")
+    install_package_from_repo(
+        name="foo",
+        url=repo_url,
+        project_root_path=Path(tmpdir),
+        destination=Path(tmpdir) / "lib",
+    )
 
     # This implicitly tests whether the install command actually creates a repo
     repo = GitRepository.from_existing(Path(tmpdir))
 
     assert len(repo.get_submodules()) == 1
+
+
+def test_not_failing_when_package_was_already_installed(tmp_path: Path, repo_url: str):
+    install_package_from_repo(
+        name="foo",
+        url=repo_url,
+        project_root_path=tmp_path,
+        destination=tmp_path / "lib",
+    )
+    install_package_from_repo(
+        name="foo",
+        url=repo_url,
+        project_root_path=tmp_path,
+        destination=tmp_path / "lib",
+    )
+
+    assert len(GitRepository.from_existing(tmp_path).get_submodules()) == 1

--- a/protostar/git/git_helpers.py
+++ b/protostar/git/git_helpers.py
@@ -32,17 +32,18 @@ def run_git(*args: Union[str, Path], cwd: Path):
     credentials = [] if has_user_git_credentials() else DEFAULT_CREDENTIALS
     str_args: list[str] = [str(arg) for arg in args]
     try:
-        return (
-            subprocess.run(
-                ["git", *credentials, *str_args],
-                check=True,
-                cwd=cwd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            .stdout.decode("utf-8")
-            .strip()
+        result = subprocess.run(
+            ["git", *credentials, *str_args],
+            check=False,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
+        output = result.stdout.decode("utf-8").strip()
+        if result.returncode == 0:
+            return output
+        raise ProtostarGitException(" ".join(["git", *str_args]) + "\n\n" + output)
+
     except subprocess.CalledProcessError as ex:
         raise ProtostarGitException(str(ex)) from ex
 

--- a/protostar/git/git_helpers_test.py
+++ b/protostar/git/git_helpers_test.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import pytest
+
+from .git_exceptions import ProtostarGitException
+from .git_helpers import run_git
+
+
+def test_exception_is_descriptive(tmp_path: Path):
+    run_git("init", cwd=tmp_path)
+
+    with pytest.raises(ProtostarGitException, match="nothing to commit"):
+        run_git("commit", "-m", "fail because no staged files", cwd=tmp_path)

--- a/protostar/git/git_repository.py
+++ b/protostar/git/git_repository.py
@@ -19,7 +19,7 @@ class Submodule:
 
 @dataclass
 class GitStatusResult:
-    files_to_be_committed: list[Path]
+    staged_file_paths: list[Path]
 
 
 class GitRepository:
@@ -105,7 +105,7 @@ class GitRepository:
         return self._git("rev-parse", "HEAD")
 
     def get_status(self) -> GitStatusResult:
-        result = GitStatusResult(files_to_be_committed=[])
+        result = GitStatusResult(staged_file_paths=[])
         output = self._git("status", "--porcelain")
         lines = output.splitlines()
         for line in lines:
@@ -114,7 +114,7 @@ class GitRepository:
             status = segments[0]
             file_path = segments[1]
             if status != "??":
-                result.files_to_be_committed.append(Path(file_path))
+                result.staged_file_paths.append(Path(file_path))
         return result
 
     def fetch_tags(self):

--- a/protostar/git/git_repository_test.py
+++ b/protostar/git/git_repository_test.py
@@ -38,3 +38,16 @@ def test_load_existing_repo(tmp_path: Path):
         InvalidGitRepositoryException, match=re.escape("is not a valid git repository.")
     ):
         GitRepository.from_existing(tmp_path)
+
+
+def test_git_status(tmp_path: Path):
+    repo = GitRepository.create(tmp_path)
+    file_1_path = tmp_path / "file_1.txt"
+    file_2_path = tmp_path / "file_2.txt"
+    file_1_path.touch()
+    file_2_path.touch()
+
+    repo.add(file_1_path)
+    status = repo.get_status()
+
+    assert status.files_to_be_committed == [Path("file_1.txt")]

--- a/protostar/git/git_repository_test.py
+++ b/protostar/git/git_repository_test.py
@@ -50,4 +50,4 @@ def test_git_status(tmp_path: Path):
     repo.add(file_1_path)
     status = repo.get_status()
 
-    assert status.files_to_be_committed == [Path("file_1.txt")]
+    assert status.staged_file_paths == [Path("file_1.txt")]


### PR DESCRIPTION
Make git errors more descriptive. Don't crash when committing unstaged files.
Closes: https://github.com/software-mansion/protostar/issues/1290

Before:
![Screenshot 2023-02-13 at 16 52 08](https://user-images.githubusercontent.com/9629577/218506171-56722d8e-a5d1-4732-bc26-2334af2f5b3c.png)

After (but before fixing this concrete problem):
![Screenshot 2023-02-13 at 16 51 34](https://user-images.githubusercontent.com/9629577/218506179-84f28812-4c7a-454e-8a5e-faf6288f04f0.png)
