### PR TITLE
Set fixed poetry version to 1.3.2 in all Actions

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Set up Python 3.9.14
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.14
+          python-version: ${{ vars.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.3.2
+          pip install poetry==${{ vars.POETRY_VERSION }}
           poetry config virtualenvs.create false
           poetry export -o requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.3.2
           poetry config virtualenvs.create false
           poetry export -o requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/builds_on_mac.yml
+++ b/.github/workflows/builds_on_mac.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup package manager
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.3.2
           poetry config virtualenvs.create false
           
       - name: Install project dependencies

--- a/.github/workflows/builds_on_mac.yml
+++ b/.github/workflows/builds_on_mac.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9.14
+      - name: Set up Python ${{ vars.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.14
+          python-version: ${{ vars.PYTHON_VERSION }}
 
       - name: Setup package manager
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.3.2
+          pip install poetry==${{ vars.POETRY_VERSION }}
           poetry config virtualenvs.create false
           
       - name: Install project dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install poetry, and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.3.2
           poetry install
       - name: Install cairo bindings
         run: |
@@ -50,7 +50,7 @@ jobs:
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.3.2
       - name: Restore caches
         uses: actions/cache@v3
         with:
@@ -86,7 +86,7 @@ jobs:
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.3.2
         shell: bash
       - name: Restore caches
         uses: actions/cache@v3
@@ -123,7 +123,7 @@ jobs:
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.3.2
       - name: Restore caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.14
+          python-version: ${{ vars.PYTHON_VERSION }}
       - name: Install poetry, and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.3.2
+          pip install poetry==${{ vars.POETRY_VERSION }}
           poetry install
       - name: Install cairo bindings
         run: |
@@ -46,11 +46,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.14
+          python-version: ${{ vars.PYTHON_VERSION }}
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.3.2
+          pip install poetry==${{ vars.POETRY_VERSION }}
       - name: Restore caches
         uses: actions/cache@v3
         with:
@@ -82,11 +82,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.14
+          python-version: ${{ vars.PYTHON_VERSION }}
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.3.2
+          pip install poetry==${{ vars.POETRY_VERSION }}
         shell: bash
       - name: Restore caches
         uses: actions/cache@v3
@@ -119,11 +119,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.14
+          python-version: ${{ vars.PYTHON_VERSION }}
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry==1.3.2
+          pip install poetry==${{ vars.POETRY_VERSION }}
       - name: Restore caches
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
_"Whatever method you use, it is highly recommended to explicitly control the version of Poetry used, so that you are able to upgrade after performing your own validation."_

Source: https://python-poetry.org/docs/master/#ci-recommendations

Related issue on CI:
https://github.com/software-mansion/protostar/actions/runs/4292622238/jobs/7479310114


