### PR TITLE
Set rust version to `nightly-2022-11-03` in `install_cairo_bindings.sh`

### DIFF
--- a/scripts/install_cairo_bindings.sh
+++ b/scripts/install_cairo_bindings.sh
@@ -17,7 +17,7 @@ function install_dev() {
 
   pushd cairo
   pushd crates/cairo-lang-python-bindings
-  rustup override set nightly || return 1;
+  rustup override set nightly-2022-11-03 || return 1;
   maturin develop --release || return 1;
   popd # cairo
   popd # cairo/crates/cairo_python_bindings
@@ -28,7 +28,7 @@ function install_prod() {
 
   pushd cairo
   pushd crates/cairo-lang-python-bindings
-  rustup override set nightly || return 1;
+  rustup override set nightly-2022-11-03 || return 1;
   maturin build || return 1;
   popd # cairo
 


### PR DESCRIPTION
Cairo 1 own CI uses specific nightly version https://github.com/software-mansion-labs/cairo/blob/a373e713b4eb306eb091970de1a1a9644e10fc12/.github/workflows/ci.yml#L77

We should use the same version in our scripts instead of pulling the latest release which can contain problems.