### PR TITLE
Use Cairo tests configs

### DIFF
--- a/protostar/cairo/cairo_bindings.py
+++ b/protostar/cairo/cairo_bindings.py
@@ -10,6 +10,9 @@ from protostar.cairo.cairo_function_runner_facade import RUNNER_BUILTINS_TITLE_C
 from .cairo_exceptions import CairoBindingException
 
 
+CairoTestConfig = tuple[Optional[int], bool, bool]
+
+
 def ensure_output_path(output_path: Optional[Path]):
     if output_path:
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
@@ -18,7 +21,7 @@ def ensure_output_path(output_path: Optional[Path]):
 @dataclass
 class TestCollectorOutput:
     sierra_output: Optional[str]
-    test_names: list[str]
+    named_tests: list[tuple[str, CairoTestConfig]]
 
 
 def compile_starknet_contract_to_casm_from_path(
@@ -62,7 +65,7 @@ def collect_tests(
             [str(path) for path in cairo_path] if cairo_path else None,
             RUNNER_BUILTINS_TITLE_CASE,
         )
-        return TestCollectorOutput(sierra_output=output[0], test_names=output[1])
+        return TestCollectorOutput(sierra_output=output[0], named_tests=output[1])
 
 
 def compile_protostar_sierra_to_casm_from_path(
@@ -77,13 +80,19 @@ def compile_protostar_sierra_to_casm_from_path(
 
 
 def compile_protostar_sierra_to_casm(
-    named_tests: list[str], input_data: str, output_path: Optional[Path] = None
+    named_tests: list[str],
+    input_data: str,
+    output_path: Optional[Path] = None,
+    cairo_tests_configs: Optional[list[CairoTestConfig]] = None,
 ) -> Optional[dict]:
     ensure_output_path(output_path=output_path)
     with handle_bindings_errors("compile_protostar_sierra_to_casm"):
         compiled_str = (
             cairo_python_bindings.compile_protostar_sierra_to_casm(  # pyright: ignore
-                named_tests, input_data, str(output_path) if output_path else None
+                named_tests,
+                input_data,
+                str(output_path) if output_path else None,
+                cairo_tests_configs,
             )
         )
         return json.loads(compiled_str)
@@ -93,7 +102,7 @@ def compile_protostar_sierra_to_casm(
 def handle_bindings_errors(binding_name: str):
     try:
         yield
-    except RuntimeError as ex:
+    except BaseException as ex:
         raise CairoBindingException(
             message=f"An error occurred in binding {binding_name}: {str(ex)}"
         ) from ex

--- a/protostar/cairo_testing/cairo1_test_collector.py
+++ b/protostar/cairo_testing/cairo1_test_collector.py
@@ -22,11 +22,12 @@ class Cairo1TestCollector(TestCollector):
         )
         self._cairo_path = cairo_path
         self._cairo_1_test_path_to_sierra_output: dict[Path, str] = {}
+        self.cairo_tests_configs: list[cairo1.CairoTestConfig] = []
 
     def collect_cairo1_tests_and_cache_outputs(
         self,
         file_path: Path,
-    ) -> List[str]:
+    ) -> list[str]:
         try:
             collector_output = cairo1.collect_tests(
                 file_path,
@@ -43,9 +44,12 @@ class Cairo1TestCollector(TestCollector):
         self._cairo_1_test_path_to_sierra_output[
             file_path
         ] = collector_output.sierra_output
+        self.cairo_tests_configs = [
+            config for _, config in collector_output.named_tests
+        ]
         return [
             namespaced_test_name.split("::")[-1]
-            for namespaced_test_name in collector_output.test_names
+            for namespaced_test_name, _ in collector_output.named_tests
         ]
 
     def _build_test_suite_from_test_suite_info(

--- a/protostar/cairo_testing/cairo1_test_runner.py
+++ b/protostar/cairo_testing/cairo1_test_runner.py
@@ -195,6 +195,7 @@ class Cairo1TestRunner:
                     test_case.test_fn_name for test_case in test_suite.test_cases
                 ],
                 input_data=test_suite.sierra_output,
+                cairo_tests_configs=test_suite.cairo_tests_configs,
             )
 
             assert casm_json, f"No CASM was emitted for {test_suite.test_path}"

--- a/protostar/testing/test_collector.py
+++ b/protostar/testing/test_collector.py
@@ -13,6 +13,7 @@ from starkware.cairo.lang.compiler.preprocessor.preprocessor_error import (
 )
 
 from protostar.cairo.cairo_exceptions import CairoBindingException
+import protostar.cairo.cairo_bindings as cairo1
 
 from .test_results import BrokenTestSuiteResult
 from .test_suite import TestCase, TestSuite
@@ -105,6 +106,7 @@ class TestCollector:
         get_suite_function_names: FunctionNameGetter,
     ) -> None:
         self._get_suite_function_names = get_suite_function_names
+        self.cairo_tests_configs: list[cairo1.CairoTestConfig] = []
 
     supported_test_suite_filename_patterns = [
         re.compile(r"^test_.*\.cairo"),
@@ -285,10 +287,15 @@ class TestCollector:
             )
         )
 
+        cairo_tests_configs = []
+        if hasattr(self, "cairo_tests_configs"):
+            cairo_tests_configs = self.cairo_tests_configs
+
         return TestSuite(
             test_path=test_suite_info.path,
             test_cases=test_cases,
             setup_fn_name=setup_fn_name,
+            cairo_tests_configs=cairo_tests_configs,
         )
 
     def _collect_test_cases(

--- a/protostar/testing/test_suite.py
+++ b/protostar/testing/test_suite.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 from typing_extensions import Self
 
 from protostar.cairo.cairo_function_executor import Offset
+import protostar.cairo.cairo_bindings as cairo1
 
 
 class TestCase:
@@ -44,10 +45,12 @@ class TestSuite:
         test_path: Path,
         test_cases: TestCases,
         setup_fn_name: Optional[str] = None,
+        cairo_tests_configs: Optional[list[cairo1.CairoTestConfig]] = None,
     ):
         self.test_path = test_path
         self.test_cases = test_cases
         self.setup_fn_name = setup_fn_name
+        self.cairo_tests_configs = cairo_tests_configs if cairo_tests_configs else []
 
     def collect_test_case_names(self) -> List[str]:
         return [tc.test_fn_name for tc in self.test_cases]
@@ -60,10 +63,12 @@ class Cairo1TestSuite(TestSuite):
         test_cases: TestCases,
         sierra_output: str,
         setup_fn_name: Optional[str] = None,
+        cairo_tests_configs: Optional[list[cairo1.CairoTestConfig]] = None,
     ):
         super().__init__(test_path, [], setup_fn_name)
         self.test_cases = test_cases
         self.sierra_output = sierra_output
+        self.cairo_tests_configs = cairo_tests_configs
 
     @classmethod
     def from_test_suite(cls, test_suite: TestSuite, sierra_output: str) -> Self:
@@ -72,6 +77,7 @@ class Cairo1TestSuite(TestSuite):
             test_cases=test_suite.test_cases,
             setup_fn_name=test_suite.setup_fn_name,
             sierra_output=sierra_output,
+            cairo_tests_configs=test_suite.cairo_tests_configs,
         )
 
     def add_offsets_to_cases(self, offset_map: dict[str, Offset]):

--- a/tests/integration/cairo1/builtins_test.py
+++ b/tests/integration/cairo1/builtins_test.py
@@ -11,8 +11,9 @@ def test_return_value(datadir: Path):
     test_collector_output = cairo1.collect_tests(input_path=datadir / "test.cairo")
     assert test_collector_output.sierra_output
     protostar_casm_json = cairo1.compile_protostar_sierra_to_casm(
-        named_tests=test_collector_output.test_names,
+        named_tests=[name for name, _ in test_collector_output.named_tests],
         input_data=test_collector_output.sierra_output,
+        cairo_tests_configs=[config for _, config in test_collector_output.named_tests],
     )
     assert protostar_casm_json
     protostar_casm = ProtostarCasm.from_json(protostar_casm_json)

--- a/tests/integration/cairo1/cairo_runner_facade_test.py
+++ b/tests/integration/cairo1/cairo_runner_facade_test.py
@@ -11,8 +11,9 @@ def test_return_value(datadir: Path):
     test_collector_output = cairo1.collect_tests(input_path=datadir / "test.cairo")
     assert test_collector_output.sierra_output
     protostar_casm_json = cairo1.compile_protostar_sierra_to_casm(
-        named_tests=test_collector_output.test_names,
+        named_tests=[name for name, _ in test_collector_output.named_tests],
         input_data=test_collector_output.sierra_output,
+        cairo_tests_configs=[config for _, config in test_collector_output.named_tests],
     )
     assert protostar_casm_json
     protostar_casm = ProtostarCasm.from_json(protostar_casm_json)

--- a/tests/integration/cairo1_compiler_bindings/library_functions_test.py
+++ b/tests/integration/cairo1_compiler_bindings/library_functions_test.py
@@ -61,8 +61,9 @@ def check_library_function(
     test_collector_output = cairo1.collect_tests(input_path=cairo_test_path)
     assert test_collector_output.sierra_output
     protostar_casm_json = cairo1.compile_protostar_sierra_to_casm(
-        named_tests=test_collector_output.test_names,
+        named_tests=[name for name, _ in test_collector_output.named_tests],
         input_data=test_collector_output.sierra_output,
+        cairo_tests_configs=[config for _, config in test_collector_output.named_tests],
     )
     assert protostar_casm_json
     for mocked_error_code in [0, 1, 50]:

--- a/tests/integration/cairo1_compiler_bindings/test_typecheck_test.py
+++ b/tests/integration/cairo1_compiler_bindings/test_typecheck_test.py
@@ -9,7 +9,7 @@ from protostar.cairo.cairo_exceptions import CairoBindingException
 def test_typecheck_basic(datadir: Path):
     test_collector_output = cairo1.collect_tests(datadir / "test_basic.cairo")
     assert test_collector_output.sierra_output
-    assert test_collector_output.test_names
+    assert test_collector_output.named_tests
 
 
 def test_typecheck_with_args(datadir: Path):
@@ -18,7 +18,7 @@ def test_typecheck_with_args(datadir: Path):
     ):
         test_collector_output = cairo1.collect_tests(datadir / "test_with_args.cairo")
         assert test_collector_output.sierra_output
-        assert test_collector_output.test_names
+        assert test_collector_output.named_tests
 
 
 def test_typecheck_with_return_values(datadir: Path):
@@ -30,7 +30,7 @@ def test_typecheck_with_return_values(datadir: Path):
             datadir / "test_with_ret_vals.cairo"
         )
         assert test_collector_output.sierra_output
-        assert test_collector_output.test_names
+        assert test_collector_output.named_tests
 
 
 def test_typecheck_with_no_panic(datadir: Path):
@@ -39,7 +39,7 @@ def test_typecheck_with_no_panic(datadir: Path):
             datadir / "test_with_no_panic.cairo"
         )
         assert test_collector_output.sierra_output
-        assert test_collector_output.test_names
+        assert test_collector_output.named_tests
 
 
 def test_typecheck_without_panic(datadir: Path):
@@ -48,4 +48,4 @@ def test_typecheck_without_panic(datadir: Path):
             datadir / "test_without_panic.cairo"
         )
         assert test_collector_output.sierra_output
-        assert test_collector_output.test_names
+        assert test_collector_output.named_tests

--- a/tests/integration/cairo1_compiler_bindings/tests_collector_and_compiler_test.py
+++ b/tests/integration/cairo1_compiler_bindings/tests_collector_and_compiler_test.py
@@ -11,14 +11,16 @@ def test_compilator_and_parser(mocker: MockerFixture, datadir: Path):
     test_collector_output = cairo1.collect_tests(datadir / "roll_test.cairo")
 
     assert test_collector_output.sierra_output
-    assert test_collector_output.test_names == [
+    assert test_collector_output.named_tests == [
         "roll_test::roll_test::test_cheatcode_caller",
         "roll_test::roll_test::test_cheatcode_caller_twice",
         "roll_test::roll_test::test_cheatcode_caller_three",
     ]
 
     protostar_casm_json = cairo1.compile_protostar_sierra_to_casm(
-        test_collector_output.test_names, test_collector_output.sierra_output
+        named_tests=[name for name, _ in test_collector_output.named_tests],
+        input_data=test_collector_output.sierra_output,
+        cairo_tests_configs=[config for _, config in test_collector_output.named_tests],
     )
     assert protostar_casm_json
 
@@ -52,10 +54,11 @@ def test_cairo_path_for_tests(datadir: Path, shared_datadir: Path):
         ],
     )
     assert result.sierra_output
-    assert result.test_names == ["test_with_deps::test_with_deps::test_assert_true"]
+    assert result.named_tests == ["test_with_deps::test_with_deps::test_assert_true"]
 
     protostar_casm = cairo1.compile_protostar_sierra_to_casm(
-        result.test_names,
-        result.sierra_output,
+        named_tests=[name for name, _ in result.named_tests],
+        input_data=result.sierra_output,
+        cairo_tests_configs=[config for _, config in result.named_tests],
     )
     assert protostar_casm

--- a/tests/integration/pure_cairo_vm/cairo1_integration/cairo1_runner_test.py
+++ b/tests/integration/pure_cairo_vm/cairo1_integration/cairo1_runner_test.py
@@ -125,3 +125,29 @@ async def test_cairo_1_failing(
             "test_panic_multiple_values",
         ],
     )
+
+
+async def test_cairo_1_runner_with_cairo_tests_configs(
+    protostar: ProtostarFixture, datadir: Path
+):
+    testing_summary = await protostar.run_test_runner(
+        datadir / "test_cairo1_cairo_configs.cairo",
+        cairo1_test_runner=True,
+    )
+
+    test_suites = testing_summary.test_collector_result.test_suites
+    assert len(test_suites) == 1
+    test_suite = test_suites[0]
+    cairo_tests_configs = test_suite.cairo_tests_configs
+    assert set(cairo_tests_configs) == {
+        (1000001, True, False),
+        (None, False, False),
+    }
+
+    assert_cairo_test_cases(
+        testing_summary,
+        expected_passed_test_cases_names=[
+            "test_with_available_gas",
+            "test_with_should_panic",
+        ],
+    )

--- a/tests/integration/pure_cairo_vm/cairo1_integration/cairo1_runner_test/test_cairo1_cairo_configs.cairo
+++ b/tests/integration/pure_cairo_vm/cairo1_integration/cairo1_runner_test/test_cairo1_cairo_configs.cairo
@@ -1,0 +1,15 @@
+use array::ArrayTrait;
+
+#[test]
+#[available_gas(1000001)]
+fn test_with_available_gas(){
+    assert(1 == 1, 'simple check');
+}
+
+#[test]
+#[should_panic]
+fn test_with_should_panic(){
+    assert(1 == 1, 'simple check');
+}
+
+


### PR DESCRIPTION
In order to properly handle `get_gas` in the unit tests we should handle the test config that comes from the cairo code.
Here https://github.com/software-mansion-labs/cairo/blob/7628ee34558bb7d89a9c091542bcf5fa25072f31/crates/cairo-lang-test-runner/src/test_config.rs#L42 is how the attributes are read from the cairo code. We need to read `available_gas` but there are two more: `should_panic` and `ignore`.

Open question: Should we use `should_panic`?

Also, I couldn't find any usages of `#[ignore]` unfortunately, also, should we use that one?

This PR is a draft, more like a POC as I'm not sure if this approach is any good.