### PR TITLE
Change scope of errors reraised in bindings

### DIFF
--- a/protostar/cairo/cairo_bindings.py
+++ b/protostar/cairo/cairo_bindings.py
@@ -93,7 +93,11 @@ def compile_protostar_sierra_to_casm(
 def handle_bindings_errors(binding_name: str):
     try:
         yield
+    except RuntimeError as ex:
+        raise CairoBindingException(
+            message=f"A runtime error occurred in binding {binding_name}: {str(ex)}"
+        ) from ex
     except BaseException as ex:
         raise CairoBindingException(
-            message=f"An error occurred in binding {binding_name}: {str(ex)}"
+            message=f"A unexpected type of error occurred in binding {binding_name}: {str(ex)}"
         ) from ex

--- a/protostar/cairo/cairo_bindings.py
+++ b/protostar/cairo/cairo_bindings.py
@@ -93,7 +93,7 @@ def compile_protostar_sierra_to_casm(
 def handle_bindings_errors(binding_name: str):
     try:
         yield
-    except RuntimeError as ex:
+    except BaseException as ex:
         raise CairoBindingException(
             message=f"An error occurred in binding {binding_name}: {str(ex)}"
         ) from ex


### PR DESCRIPTION
I discovered that there are errors that are thrown from rust and are not `RuntimeError`. The result was, in my case, an infinite hang which is very bad. The error was something like `pyo3_runtime.PanicException`. Are there any objections to just catching everything that comes from rust (I mean errors) and turning it into `CairoBindingException`?