### PR TITLE
`tmp_path` fixtures wrappers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,15 @@
 import json
+import shutil
 import subprocess
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from socket import socket as Socket
-from typing import ContextManager, List, Protocol, Union
+from typing import ContextManager, List, Protocol, Union, Callable, Generator
 
 import pytest
 import requests
+from _pytest.tmpdir import TempPathFactory
 from starknet_py.net import AccountClient, KeyPair
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId
@@ -180,6 +182,35 @@ def devnet_fixture(
         devnet_gateway_url=devnet_gateway_url,
         predeployed_accounts=devnet_accounts,
     )
+
+
+ProtostarTmpPathFactory = Callable[[], Path]
+
+
+@pytest.fixture(name="tmp_path_factory", scope="function")
+def protostar_tmpdir_factory_fixture(
+    tmp_path_factory: TempPathFactory,
+) -> Generator[ProtostarTmpPathFactory, None, None]:
+    """
+    Wrapper for pytest tmp_path_factory, which deletes the directory after the test
+    (original implementation keeps it for 3 runs, and it clogs up the disk on CI since we use it heavily)
+    """
+    generated_dirs = []
+
+    def dir_generator() -> Path:
+        tempdir = tmp_path_factory.mktemp("protostar_tmpdir")
+        generated_dirs.append(tempdir)
+        return tempdir
+
+    yield dir_generator
+
+    for directory in generated_dirs:
+        shutil.rmtree(directory)
+
+
+@pytest.fixture(name="tmp_path", scope="function")
+def protostar_tmp_path_fixture(tmp_path_factory: ProtostarTmpPathFactory):
+    return tmp_path_factory()
 
 
 TESTS_ROOT_PATH = Path(__file__).parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def devnet_fixture(
 ProtostarTmpPathFactory = Callable[[], Path]
 
 
-@pytest.fixture(name="tmp_path_factory", scope="function")
+@pytest.fixture(name="tmp_path_factory")
 def protostar_tmpdir_factory_fixture(
     tmp_path_factory: TempPathFactory,
 ) -> Generator[ProtostarTmpPathFactory, None, None]:
@@ -208,7 +208,7 @@ def protostar_tmpdir_factory_fixture(
         shutil.rmtree(directory)
 
 
-@pytest.fixture(name="tmp_path", scope="function")
+@pytest.fixture(name="tmp_path")
 def protostar_tmp_path_fixture(tmp_path_factory: ProtostarTmpPathFactory):
     return tmp_path_factory()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -136,7 +136,7 @@ class CreateProtostarProjectFixture(Protocol):
         ...
 
 
-@pytest.fixture(name="create_protostar_project", scope="module")
+@pytest.fixture(name="create_protostar_project")
 def create_protostar_project_fixture(
     session_mocker: MockerFixture,
     tmp_path_factory: ProtostarTmpPathFactory,
@@ -172,7 +172,7 @@ def create_protostar_project_fixture(
 GetAbiFromContractFixture = Callable[[str], AbiType]
 
 
-@pytest.fixture(name="get_abi_from_contract", scope="module")
+@pytest.fixture(name="get_abi_from_contract")
 def get_abi_from_contract_fixture(
     create_protostar_project: CreateProtostarProjectFixture,
 ) -> GetAbiFromContractFixture:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Callable, ContextManager, List, Optional, cast
 
 import pytest
-from pytest import TempPathFactory
 from pytest_mock import MockerFixture
 from starkware.starknet.public.abi import AbiType
 from typing_extensions import Protocol
@@ -16,7 +15,7 @@ from protostar.compiler.project_cairo_path_builder import ProjectCairoPathBuilde
 from protostar.io.log_color_provider import LogColorProvider
 from protostar.testing import TestingSummary
 from protostar.cli import MessengerFactory
-from tests.conftest import TESTS_ROOT_PATH, run_devnet
+from tests.conftest import TESTS_ROOT_PATH, run_devnet, ProtostarTmpPathFactory
 from tests.integration._conftest import ProtostarFixture, create_protostar_fixture
 from tests.integration._conftest import (
     assert_cairo_test_cases as _assert_cairo_test_cases,
@@ -140,11 +139,11 @@ class CreateProtostarProjectFixture(Protocol):
 @pytest.fixture(name="create_protostar_project", scope="module")
 def create_protostar_project_fixture(
     session_mocker: MockerFixture,
-    tmp_path_factory: TempPathFactory,
+    tmp_path_factory: ProtostarTmpPathFactory,
 ) -> CreateProtostarProjectFixture:
     @contextmanager
     def create_protostar_project(cairo_version: CairoVersion = CairoVersion.cairo0):
-        tmp_path = tmp_path_factory.mktemp("project_name")
+        tmp_path = tmp_path_factory()
         project_root_path = tmp_path
         cwd = Path().resolve()
         protostar = create_protostar_fixture(

--- a/tests/integration/deploying/declare_command_test.py
+++ b/tests/integration/deploying/declare_command_test.py
@@ -13,7 +13,7 @@ from tests.integration.conftest import CreateProtostarProjectFixture
 from tests.integration._conftest import ProtostarFixture
 
 
-@pytest.fixture(name="protostar", scope="module")
+@pytest.fixture(name="protostar")
 def protostar_fixture(create_protostar_project: CreateProtostarProjectFixture):
     with create_protostar_project() as protostar:
         protostar.create_files({"./src/main.cairo": CONTRACT_WITH_CONSTRUCTOR})

--- a/tests/integration/deploying/deploy_command_test.py
+++ b/tests/integration/deploying/deploy_command_test.py
@@ -9,7 +9,7 @@ from tests.integration._conftest import ProtostarFixture
 from protostar.starknet_gateway.gateway_facade import InputValidationException
 
 
-@pytest.fixture(name="protostar", scope="module")
+@pytest.fixture(name="protostar")
 def protostar_fixture(create_protostar_project: CreateProtostarProjectFixture):
     with create_protostar_project() as protostar:
         protostar.create_files({"./src/main.cairo": CONTRACT_WITH_CONSTRUCTOR})

--- a/tests/integration/gateway/uint256_as_input_test.py
+++ b/tests/integration/gateway/uint256_as_input_test.py
@@ -10,7 +10,7 @@ from protostar.starknet_gateway.gateway_facade import TransactionException
 from protostar.starknet.data_transformer import CairoOrPythonData
 
 
-@pytest.fixture(name="protostar", scope="module")
+@pytest.fixture(name="protostar")
 def protostar_fixture(create_protostar_project: CreateProtostarProjectFixture):
     with create_protostar_project() as protostar:
         protostar.create_files({"./src/main.cairo": CONTRACT_WITH_UINT256_CONSTRUCTOR})


### PR DESCRIPTION
This is pretty brute-force, i'll explain what it does and why:

## The cause
`tmp_path` and `tmp_path_factory` are not actually deleted after a test case/module/test session run.
This causes to clog up the disk and fail our CI

## This PR does:
- reduce scope of some protostar-fixtures to function, to keep things contain and easy to manage from fixture
- wraps pytests fixures into our own, which are deleted after a case run