### PR TITLE
Hotfix: Uint256 pickling fuzzing issue

### DIFF
--- a/protostar/testing/fuzzing/strategies/uint256.py
+++ b/protostar/testing/fuzzing/strategies/uint256.py
@@ -24,6 +24,9 @@ def is_uint256(cairo_type: CairoType):
     )
 
 
+Uint256 = NamedTuple("Uint256", (("low", int), ("high", int)))
+
+
 class Uint256StrategyDescriptor(StrategyDescriptor):
     def __init__(
         self, min_value: Optional[int] = None, max_value: Optional[int] = None
@@ -45,8 +48,6 @@ class Uint256StrategyDescriptor(StrategyDescriptor):
             raise SearchStrategyBuildError(
                 "Strategy 'uint256' can only be applied to Uint256 parameters."
             )
-
-        Uint256 = NamedTuple("Uint256", (("low", int), ("high", int)))
 
         return integers(min_value=self.min_value, max_value=self.max_value).map(
             lambda x: Uint256(low=_get_low(x), high=_get_high(x))


### PR DESCRIPTION
[Issue on discord.](https://discord.com/channels/793094838509764618/964116575387021413/1095331790551519422)

Pickling NamedTuples created within functions is not reliable.

```cairo
@external
func setup_less_equal_compare() {
    %{
        given(
            a = strategy.integers(10, 20),
            b = strategy.uint256(),
        )
    %}
    return ();
}

@external
func test_less_equal_compare{syscall_ptr: felt*, range_check_ptr}(a: felt, b: Uint256) {
    assert_le(a, b.low);
    return ();
}
```
```
Can't pickle <class 'protostar.testing.fuzzing.strategies.uint256.Uint256'>: attribute lookup Uint256 on protostar.testing.fuzzing.strategies.uint256 failed
```