### PR TITLE
Rename library functions. Remove unused ones

### DIFF
--- a/protostar/cheatable_starknet/callable_hint_locals/deploy_hint_local.py
+++ b/protostar/cheatable_starknet/callable_hint_locals/deploy_hint_local.py
@@ -24,28 +24,24 @@ class DeployHintLocal(CallableHintLocal):
         return "deploy_impl"
 
     def _build(self) -> Callable[[list[int], int, int], Any]:
-        return self.deploy_prepared_impl
+        return self.deploy
 
-    def deploy_prepared_impl(
+    def deploy(
         self,
         constructor_calldata: list[int],
         contract_address: int,
         class_hash: int,
     ):
-        return self.deploy_prepared(
-            PreparedContract(
-                constructor_calldata=constructor_calldata,
-                contract_address=contract_address,
-                class_hash=class_hash,
-                salt=0,
+        return asyncio.run(
+            self._run_deploy_prepared(
+                PreparedContract(
+                    constructor_calldata=constructor_calldata,
+                    contract_address=contract_address,
+                    class_hash=class_hash,
+                    salt=0,
+                )
             )
         )
-
-    def deploy_prepared(
-        self,
-        prepared: PreparedContract,
-    ):
-        return asyncio.run(self._run_deploy_prepared(prepared))
 
     async def _run_deploy_prepared(self, prepared: PreparedContract):
         try:

--- a/protostar/cheatable_starknet/callable_hint_locals/deploy_hint_local.py
+++ b/protostar/cheatable_starknet/callable_hint_locals/deploy_hint_local.py
@@ -21,12 +21,12 @@ class DeployHintLocal(CallableHintLocal):
 
     @property
     def name(self) -> str:
-        return "deploy_tp"
+        return "deploy_impl"
 
     def _build(self) -> Callable[[list[int], int, int], Any]:
-        return self.deploy_prepared_tp
+        return self.deploy_prepared_impl
 
-    def deploy_prepared_tp(
+    def deploy_prepared_impl(
         self,
         constructor_calldata: list[int],
         contract_address: int,

--- a/protostar/cheatable_starknet/callable_hint_locals/prepare_hint_local.py
+++ b/protostar/cheatable_starknet/callable_hint_locals/prepare_hint_local.py
@@ -21,7 +21,7 @@ class PrepareHintLocal(CallableHintLocal):
 
     @property
     def name(self) -> str:
-        return "prepare_tp"
+        return "prepare_impl"
 
     def _build(self) -> Callable[[Any], Any]:
         return self.prepare

--- a/scripts/install_cairo_bindings.sh
+++ b/scripts/install_cairo_bindings.sh
@@ -13,6 +13,7 @@ if [ "$1" == "--cleanup" ]; then
 fi
 
 function install_dev() {
+  git pull --recurse-submodules
 
   pushd cairo
   pushd crates/cairo-lang-python-bindings
@@ -23,6 +24,7 @@ function install_dev() {
 }
 
 function install_prod() {
+  git pull --recurse-submodules
 
   pushd cairo
   pushd crates/cairo-lang-python-bindings

--- a/scripts/install_cairo_bindings.sh
+++ b/scripts/install_cairo_bindings.sh
@@ -13,7 +13,6 @@ if [ "$1" == "--cleanup" ]; then
 fi
 
 function install_dev() {
-  git pull --recurse-submodules
 
   pushd cairo
   pushd crates/cairo-lang-python-bindings
@@ -24,7 +23,6 @@ function install_dev() {
 }
 
 function install_prod() {
-  git pull --recurse-submodules
 
   pushd cairo
   pushd crates/cairo-lang-python-bindings

--- a/tests/integration/cairo1/compiler_bindings/library_functions_test.py
+++ b/tests/integration/cairo1/compiler_bindings/library_functions_test.py
@@ -31,7 +31,7 @@ def get_mock_for_lib_func(
         return_value = type(
             "return_value", (object,), {"err_code": err_code, "ok": ok}
         )()
-    elif lib_func_name == "deploy_tp":
+    elif lib_func_name == "deploy_impl":
         assert return_values_provider
         ok = type(
             "ok",
@@ -59,7 +59,7 @@ def get_mock_for_lib_func(
         return_value = type(
             "return_value", (object,), {"panic_data": panic_data, "ok": None}
         )()
-    elif lib_func_name == "prepare_tp":
+    elif lib_func_name == "prepare_impl":
         assert return_values_provider
         prepared_contract = type(
             "prepared_contract",
@@ -104,7 +104,7 @@ def compile_suite(cairo_test_path: Path) -> ProtostarCasm:
     return ProtostarCasm.from_json(protostar_casm_json)
 
 
-REVERTABLE_FUNCTIONS = ["invoke", "call", "deploy_tp"]
+REVERTABLE_FUNCTIONS = ["invoke", "call", "deploy_impl"]
 
 
 def check_library_function(
@@ -188,12 +188,12 @@ def test_deploy(datadir: Path):
     expected_calldatas = {
         "test_deploy": [1, 2],
         "test_deploy_no_args": [],
-        "test_deploy_tp": [5, 4, 2],
+        "test_deploy_impl": [5, 4, 2],
     }
     return_values = {
         "test_deploy": {"contract_address": 123},
         "test_deploy_no_args": {"contract_address": 4443},
-        "test_deploy_tp": {"contract_address": 0},
+        "test_deploy_impl": {"contract_address": 0},
     }
 
     def _args_validator(test_case_name: str, *args: Any, **kwargs: Any):
@@ -206,7 +206,7 @@ def test_deploy(datadir: Path):
         return return_values[extract_test_case_name(test_case_name)]
 
     check_library_function(
-        "deploy_tp",
+        "deploy_impl",
         datadir / "deploy_test.cairo",
         args_validator=_args_validator,
         return_values_provider=_return_values_provider,
@@ -233,7 +233,7 @@ def test_invoke(datadir: Path):
 def test_prepare(datadir: Path):
     expected_calldatas = {
         "test_prepare": [101, 202, 613, 721],
-        "test_prepare_tp": [3, 2, 1],
+        "test_prepare_impl": [3, 2, 1],
         "test_prepare_no_args": [],
     }
     return_values = {
@@ -242,7 +242,7 @@ def test_prepare(datadir: Path):
             "contract_address": 111,
             "class_hash": 222,
         },
-        "test_prepare_tp": {
+        "test_prepare_impl": {
             "constructor_calldata": [3, 2, 1],
             "contract_address": 0,
             "class_hash": 444,
@@ -264,7 +264,7 @@ def test_prepare(datadir: Path):
         return return_values[extract_test_case_name(test_case_name)]
 
     check_library_function(
-        "prepare_tp",
+        "prepare_impl",
         datadir / "prepare_test.cairo",
         args_validator=_args_validator,
         return_values_provider=_return_values_provider,
@@ -330,8 +330,8 @@ def test_deploy_contract(datadir: Path):
                     test_case_name=test_case_name,
                     return_values_provider=lambda _: {"class_hash": 123},  # type: ignore
                 ),
-                "prepare_tp": get_mock_for_lib_func(
-                    lib_func_name="prepare_tp",
+                "prepare_impl": get_mock_for_lib_func(
+                    lib_func_name="prepare_impl",
                     err_code=0,
                     cairo_runner_facade=cairo_runner_facade,
                     test_case_name=test_case_name,
@@ -341,8 +341,8 @@ def test_deploy_contract(datadir: Path):
                         "class_hash": 123,
                     },
                 ),
-                "deploy_tp": get_mock_for_lib_func(
-                    lib_func_name="deploy_tp",
+                "deploy_impl": get_mock_for_lib_func(
+                    lib_func_name="deploy_impl",
                     err_code=0,
                     cairo_runner_facade=cairo_runner_facade,
                     test_case_name=test_case_name,

--- a/tests/integration/cairo1/compiler_bindings/library_functions_test/deploy_test.cairo
+++ b/tests/integration/cairo1/compiler_bindings/library_functions_test/deploy_test.cairo
@@ -31,12 +31,12 @@ fn test_deploy_no_args() {
 }
 
 #[test]
-fn test_deploy_tp() {
+fn test_deploy_impl() {
    let mut arr = ArrayTrait::new();
    arr.append(5);
    arr.append(4);
    arr.append(2);
-   match deploy_tp(123, 234, arr) {
+   match deploy_impl(123, 234, arr) {
       Result::Ok(deployed_contract_address) => {
         assert(deployed_contract_address == 0, 'check deployed_contract_address');
         ()

--- a/tests/integration/cairo1/compiler_bindings/library_functions_test/prepare_test.cairo
+++ b/tests/integration/cairo1/compiler_bindings/library_functions_test/prepare_test.cairo
@@ -27,12 +27,12 @@ fn test_prepare() {
 }
 
 #[test]
-fn test_prepare_tp() {
+fn test_prepare_impl() {
    let mut arr = ArrayTrait::new();
    arr.append(3);
    arr.append(2);
    arr.append(1);
-   match prepare_tp(123, arr) {
+   match prepare_impl(123, arr) {
       Result::Ok((constructor_calldata, contract_address, class_hash)) => {
         assert(constructor_calldata.len() == 3_u32, 'check constructor_calldata');
         assert(*constructor_calldata.at(0_usize) == 3, 'check constructor_calldata[0]');


### PR DESCRIPTION
Cairo PR: [68](https://github.com/software-mansion-labs/cairo/pull/68)

This PR also removes unused and obsolete libfuncs versions for cairo0

### Checklist
- [x] Relevant issue is linked
- [x] Docs updated/issue for docs created
- [x] Added relevant tests
