### PR TITLE
Fix snapshot arguments in docs

### DIFF
--- a/website/docs/cairo-1/05-testing/02-integration-testing.md
+++ b/website/docs/cairo-1/05-testing/02-integration-testing.md
@@ -37,8 +37,8 @@ use result::ResultTrait;
 
 #[test]
 fn test_deploy() {
-    let deployed_contract_address = deploy_contract('minimal', ArrayTrait::new()).unwrap();
-    invoke(deployed_contract_address, 'hello', ArrayTrait::new()).unwrap();
+    let deployed_contract_address = deploy_contract('minimal', @ArrayTrait::new()).unwrap();
+    invoke(deployed_contract_address, 'hello', @ArrayTrait::new()).unwrap();
 }
 ```
 [deploy_contract](./cheatcodes-reference/deploy_contract.md) will declare and deploy the given contract. [invoke](./cheatcodes-reference/invoke.md) will invoke `hello` method.
@@ -64,13 +64,13 @@ use result::ResultTrait;
 
 #[test]
 fn test_invoke_errors() {
-    let deployed_contract_address = deploy_contract('minimal', ArrayTrait::new()).unwrap();
+    let deployed_contract_address = deploy_contract('minimal', @ArrayTrait::new()).unwrap();
     let mut panic_data = ArrayTrait::new();
     panic_data.append(2); // Array length
     panic_data.append('error');
     panic_data.append('data');
     
-    match invoke(deployed_contract_address, 'panic_with', panic_data) {
+    match invoke(deployed_contract_address, 'panic_with', @panic_data) {
         Result::Ok(x) => assert(false, 'Shouldnt have succeeded'),
         Result::Err(x) => {
             assert(x.first() == 'error', 'first datum doesnt match');

--- a/website/docs/cairo-1/05-testing/03-cheatcodes.md
+++ b/website/docs/cairo-1/05-testing/03-cheatcodes.md
@@ -36,9 +36,9 @@ use array::ArrayTrait;
 
 #[test]
 fn test_invoke_errors() {
-    let contract_address = deploy_contract('minimal', ArrayTrait::new()).unwrap();
+    let contract_address = deploy_contract('minimal', @ArrayTrait::new()).unwrap();
     start_prank(123, contract_address);
-    invoke(contract_address, 'is_expected_user', ArrayTrait::new()).unwrap();
+    invoke(contract_address, 'is_expected_user', @ArrayTrait::new()).unwrap();
 }
 ```
 

--- a/website/docs/cairo-1/05-testing/README.md
+++ b/website/docs/cairo-1/05-testing/README.md
@@ -4,5 +4,6 @@ sidebar_label: Testing
 
 # Testing
 
-Protostar provides developers with a comprehensive testing environment. You can test your code using fast [unit tests](./01-unit-testing.md) or flexible [integration tests](./02-integration-testing.md)
+Protostar provides developers with a comprehensive testing environment. You can test your code using
+fast [unit tests](./01-unit-testing.md) or flexible [integration tests](./02-integration-testing.md)
 

--- a/website/docs/cairo-1/05-testing/cheatcodes-reference/call.md
+++ b/website/docs/cairo-1/05-testing/cheatcodes-reference/call.md
@@ -1,7 +1,7 @@
 # `call`
 
 ```cairo
-extern fn call(contract: felt252, function_name: felt252, calldata: Array::<felt252>) -> Result::<(Array::<felt252>), RevertedTransaction> nopanic;
+extern fn call(contract: felt252, function_name: felt252, calldata: @Array::<felt252>) -> Result::<(Array::<felt252>), RevertedTransaction> nopanic;
 
 struct RevertedTransaction {
     panic_data: Array::<felt252>, 
@@ -28,7 +28,7 @@ fn test_call() {
     calldata.append(3);
     calldata.append(2);
     calldata.append(5);
-    let return_data2 = call(deployed_contract_address, 'foo', calldata).unwrap();
+    let return_data2 = call(deployed_contract_address, 'foo', @calldata).unwrap();
     assert(*return_data2.at(0_u32) == 25, 'check call result');
 }
 ```

--- a/website/docs/cairo-1/05-testing/cheatcodes-reference/start_roll.md
+++ b/website/docs/cairo-1/05-testing/cheatcodes-reference/start_roll.md
@@ -36,14 +36,14 @@ use result::ResultTrait;
 
 #[test]
 fn test_start_roll() {
-    let deployed_contract_address = deploy_contract('simple', ArrayTrait::new()).unwrap();
+    let deployed_contract_address = deploy_contract('simple', @ArrayTrait::new()).unwrap();
     assert(deployed_contract_address != 0, 'deployed_contract_address != 0');
 
-    let result = call(deployed_contract_address, 'check_block_number', ArrayTrait::new()).unwrap();
+    let result = call(deployed_contract_address, 'check_block_number', @ArrayTrait::new()).unwrap();
     assert(*result.at(0_u32) == -1, *result.at(0_u32));
 
     start_roll(100, deployed_contract_address);
-    let result = call(deployed_contract_address, 'check_block_number', ArrayTrait::new()).unwrap();
+    let result = call(deployed_contract_address, 'check_block_number', @ArrayTrait::new()).unwrap();
     assert(*result.at(0_u32) == 100, *result.at(0_u32));
 }
 ```


### PR DESCRIPTION
Some of the pages were still using just arrays for calldata. This PR updates docs to use snapshots instead (as cheatcodes are defined currently).

### Checklist
- [ ] Relevant issue is linked
- [ ] Docs updated/issue for docs created
- [ ] Added relevant tests
