### PR TITLE
Disable output buffering for tests + build docs on all PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,7 @@ commands:
       - run:
           name: Run integration tests
           command: |
+            export PYTHONUNBUFFERED=1
             poetry run pytest -n4 --random-order scripts tests/integration
 
   run_e2e_tests:
@@ -268,6 +269,7 @@ commands:
       - run:
           name: Run e2e tests
           command: |
+            export PYTHONUNBUFFERED=1
             poetry run pytest -n4 tests/e2e
 
   notify_about_failed_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,13 +460,6 @@ jobs:
           key: yarn-docs-{{ checksum "website/yarn.lock" }}
           paths:
             - ~/.cache/yarn
-      - run:
-          name: Pack docs
-          command: tar -czvf protostar-docs.tar.gz website/build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - protostar-docs.tar.gz
 
   patch_approval_check:
     parameters:
@@ -522,11 +515,7 @@ workflows:
             branches:
               only:
                 - master
-      - build_docs:
-          filters:
-            branches:
-              only:
-                - master
+      - build_docs
       - send_test_release_approval:
           type: approval
           requires:


### PR DESCRIPTION
Context: https://support.circleci.com/hc/en-us/articles/360045268074?input_string=macos+medium+runner+slowness

I have observed a couple of jobs that failed for master, and they seemed to buffer the output. However, if the issue persist I will just create a ticket to circleci (because macos jobs shouldn't take much longer to run in comparison to linux jobs on similar speced machines)

+ as requested, added building docs check for all PRs

### Checklist
- [X] Relevant issue is linked
- [X] Docs updated/issue for docs created
- [X] Added relevant tests
