### PR TITLE
Create distinctive tags for pre-releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,8 +461,9 @@ jobs:
             if [ << parameters.prerelease >> = true ]; then
               type="--prerelease"
               name="prerelease"
+              preversion="$VERSION-pre-release"
             fi
-            gh release create "$VERSION" /tmp/workspace/*.tar.gz --title "$VERSION" --repo "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" $type
+            gh release create "${preversion:-$VERSION}" /tmp/workspace/*.tar.gz --title "${preversion:-$VERSION}" --repo "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME" $type
             ./scripts/notify.sh "good" \
             "*New ${name:-"release"} has just been published* :tada:" \
             "*Version:*\n$VERSION\n\n*Approver:*\n$CIRCLE_USERNAME" "$SLACK_URL"


### PR DESCRIPTION
This change make pre-release tags distinctive, so someone who wants to release it does not have to remember about multiple version bumps.

### Checklist
- [X] Relevant issue is linked
- [X] Docs updated/issue for docs created
- [X] Added relevant tests
